### PR TITLE
feat: Phase 2 queue infrastructure with deduplication and retention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "commander": "^14.0.3",
         "croner": "^10.0.1",
         "fastify": "^5.7.4",
+        "jsonpath-plus": "^10.4.0",
         "pino": "^10.3.1",
         "zod": "^4.3.6"
       },
@@ -1604,6 +1605,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -3906,7 +3931,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -5917,6 +5941,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5965,6 +5999,24 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "commander": "^14.0.3",
     "croner": "^10.0.1",
     "fastify": "^5.7.4",
+    "jsonpath-plus": "^10.4.0",
     "pino": "^10.3.1",
     "zod": "^4.3.6"
   },

--- a/src/db/maintenance.test.ts
+++ b/src/db/maintenance.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for database maintenance tasks.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { pino } from 'pino';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeConnection, createConnection } from './connection.js';
+import { createMaintenance } from './maintenance.js';
+import { runMigrations } from './migrations.js';
+
+describe('Maintenance', () => {
+  let testDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'jeeves-runner-test-'));
+    dbPath = join(testDir, 'test.db');
+    const db = createConnection(dbPath);
+    runMigrations(db);
+    closeConnection(db);
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+  });
+
+  it('should prune old queue items based on retention_days', () => {
+    const db = createConnection(dbPath);
+    const logger = pino({ level: 'silent' });
+
+    // Create a test queue with 7-day retention
+    db.prepare(
+      `INSERT INTO queues (id, name, max_attempts, retention_days) 
+       VALUES ('test-retention', 'Test Retention', 1, 7)`,
+    ).run();
+
+    // Insert an old completed item (10 days ago)
+    db.prepare(
+      `INSERT INTO queue_items (queue_id, payload, status, finished_at) 
+       VALUES ('test-retention', '{"test": "old"}', 'done', datetime('now', '-10 days'))`,
+    ).run();
+
+    // Insert a recent completed item (3 days ago)
+    db.prepare(
+      `INSERT INTO queue_items (queue_id, payload, status, finished_at) 
+       VALUES ('test-retention', '{"test": "recent"}', 'done', datetime('now', '-3 days'))`,
+    ).run();
+
+    // Insert a pending item (should never be pruned)
+    db.prepare(
+      `INSERT INTO queue_items (queue_id, payload, status) 
+       VALUES ('test-retention', '{"test": "pending"}', 'pending')`,
+    ).run();
+
+    const maintenance = createMaintenance(
+      db,
+      { runRetentionDays: 30, cursorCleanupIntervalMs: 60000 },
+      logger,
+    );
+
+    maintenance.runNow();
+
+    // Check that old item was pruned
+    const items = db
+      .prepare('SELECT payload FROM queue_items WHERE queue_id = ?')
+      .all('test-retention') as Array<{ payload: string }>;
+
+    expect(items).toHaveLength(2);
+    const payloads = items.map(
+      (i) => JSON.parse(i.payload) as { test: string },
+    );
+    expect(payloads.some((p) => p.test === 'old')).toBe(false);
+    expect(payloads.some((p) => p.test === 'recent')).toBe(true);
+    expect(payloads.some((p) => p.test === 'pending')).toBe(true);
+
+    maintenance.stop();
+    closeConnection(db);
+  });
+
+  it('should use default retention when queue not defined', () => {
+    const db = createConnection(dbPath);
+    const logger = pino({ level: 'silent' });
+
+    // Insert an old completed item for an undefined queue (10 days ago)
+    db.prepare(
+      `INSERT INTO queue_items (queue_id, payload, status, finished_at) 
+       VALUES ('undefined-queue', '{"test": "old"}', 'done', datetime('now', '-10 days'))`,
+    ).run();
+
+    // Insert a recent completed item (3 days ago)
+    db.prepare(
+      `INSERT INTO queue_items (queue_id, payload, status, finished_at) 
+       VALUES ('undefined-queue', '{"test": "recent"}', 'done', datetime('now', '-3 days'))`,
+    ).run();
+
+    const maintenance = createMaintenance(
+      db,
+      { runRetentionDays: 30, cursorCleanupIntervalMs: 60000 },
+      logger,
+    );
+
+    maintenance.runNow();
+
+    // Old item should be pruned (default 7-day retention)
+    const items = db
+      .prepare('SELECT payload FROM queue_items WHERE queue_id = ?')
+      .all('undefined-queue') as Array<{ payload: string }>;
+
+    expect(items).toHaveLength(1);
+    const payload = JSON.parse(items[0].payload) as { test: string };
+    expect(payload.test).toBe('recent');
+
+    maintenance.stop();
+    closeConnection(db);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export type { RunnerConfig } from './schemas/config.js';
 export { runnerConfigSchema } from './schemas/config.js';
 export type { Job } from './schemas/job.js';
 export { jobSchema } from './schemas/job.js';
+export type { Queue } from './schemas/queue.js';
+export { queueSchema } from './schemas/queue.js';
 export type { Run, RunStatus, RunTrigger } from './schemas/run.js';
 export { runSchema, runStatusSchema, runTriggerSchema } from './schemas/run.js';
 

--- a/src/schemas/queue.ts
+++ b/src/schemas/queue.ts
@@ -1,0 +1,30 @@
+/**
+ * Queue definition schema and types.
+ *
+ * @module
+ */
+
+import { z } from 'zod';
+
+/** Queue definition schema for managing queue behavior and retention. */
+export const queueSchema = z.object({
+  /** Unique queue identifier. */
+  id: z.string(),
+  /** Human-readable queue name. */
+  name: z.string(),
+  /** Optional queue description. */
+  description: z.string().nullable().optional(),
+  /** JSONPath expression for deduplication key extraction. */
+  dedupExpr: z.string().nullable().optional(),
+  /** Deduplication scope: 'pending' checks pending/processing items, 'all' checks all non-failed items. */
+  dedupScope: z.enum(['pending', 'all']).default('pending'),
+  /** Maximum retry attempts before dead-lettering. */
+  maxAttempts: z.number().default(1),
+  /** Retention period in days for completed/failed items. */
+  retentionDays: z.number().default(7),
+  /** Queue creation timestamp. */
+  createdAt: z.string(),
+});
+
+/** Inferred Queue type from schema. */
+export type Queue = z.infer<typeof queueSchema>;


### PR DESCRIPTION
## Phase 2: Queue Infrastructure

### Migration 002
- Renamed `queues` table → `queue_items`
- New `queues` definition table (id, name, dedup_expr, dedup_scope, max_attempts, retention_days)
- Seeded 4 queue definitions: email-updates, email-pending, x-posts, gh-collabs
- Added `dedup_key` column + indexes on `queue_items`

### Client Library
- **Dedup**: `enqueue()` evaluates JSONPath (`jsonpath-plus`) against payload, checks for duplicates per `dedup_scope` (pending/all), returns -1 if duplicate
- **Dead-letter**: `fail()` retries if attempts < max_attempts, otherwise marks failed
- **Backward compat**: queues without definitions still work normally

### Maintenance
- Queue item retention pruning (per-queue `retention_days`, default 7)

### Tests
- 32 tests pass (6 new dedup/dead-letter/retention tests + 2 maintenance tests)
- All STAN checks green