### PR TITLE
feat: native session dispatch via Gateway API

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for Gateway client.
+ *
+ * Note: These tests verify the client structure and mock the underlying HTTP calls.
+ * Integration tests against a real Gateway should be done separately.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createGatewayClient } from './client.js';
+
+describe('Gateway client', () => {
+  it('creates a client with required methods', () => {
+    const client = createGatewayClient({
+      url: 'http://localhost:18789',
+      token: 'test-token',
+    });
+
+    expect(client).toHaveProperty('spawnSession');
+    expect(client).toHaveProperty('getSessionHistory');
+    expect(client).toHaveProperty('getSessionInfo');
+    expect(client).toHaveProperty('isSessionComplete');
+    expect(typeof client.spawnSession).toBe('function');
+    expect(typeof client.getSessionHistory).toBe('function');
+    expect(typeof client.getSessionInfo).toBe('function');
+    expect(typeof client.isSessionComplete).toBe('function');
+  });
+
+  it('accepts optional timeout parameter', () => {
+    const client = createGatewayClient({
+      url: 'http://localhost:18789',
+      token: 'test-token',
+      timeoutMs: 60000,
+    });
+
+    expect(client).toBeDefined();
+  });
+
+  it('uses default timeout if not specified', () => {
+    const client = createGatewayClient({
+      url: 'http://localhost:18789',
+      token: 'test-token',
+    });
+
+    expect(client).toBeDefined();
+  });
+});

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -1,0 +1,223 @@
+/**
+ * OpenClaw Gateway HTTP client for spawning and monitoring sessions.
+ */
+
+import type { IncomingMessage } from 'node:http';
+import { request as httpRequest } from 'node:http';
+
+/** Options for creating a Gateway client. */
+export interface GatewayClientOptions {
+  /** Gateway base URL (e.g., http://127.0.0.1:18789). */
+  url: string;
+  /** Bearer token for authentication. */
+  token: string;
+  /** Request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+/** Options for spawning a session. */
+export interface SpawnSessionOptions {
+  /** Optional session label. */
+  label?: string;
+  /** Thinking level: low, medium, or high. */
+  thinking?: 'low' | 'medium' | 'high';
+  /** Run timeout in seconds. */
+  runTimeoutSeconds?: number;
+}
+
+/** Result of spawning a session. */
+export interface SpawnSessionResult {
+  /** Session key for tracking. */
+  sessionKey: string;
+  /** Run identifier. */
+  runId: string;
+}
+
+/** Session history message. */
+export interface SessionMessage {
+  /** Message role (user, assistant, etc.). */
+  role: string;
+  /** Stop reason (if present, indicates completion). */
+  stopReason?: string;
+}
+
+/** Session information from sessions_list. */
+export interface SessionInfo {
+  /** Total tokens used. */
+  totalTokens: number;
+  /** Model name. */
+  model: string;
+  /** Transcript file path (if available). */
+  transcriptPath?: string;
+}
+
+/** Gateway client for invoking tools via /tools/invoke. */
+export interface GatewayClient {
+  /** Spawn a new session with the given task. */
+  spawnSession(
+    task: string,
+    options?: SpawnSessionOptions,
+  ): Promise<SpawnSessionResult>;
+  /** Get session history messages. */
+  getSessionHistory(
+    sessionKey: string,
+    limit?: number,
+  ): Promise<SessionMessage[]>;
+  /** Get session info (tokens, model, etc.). Returns null if not found. */
+  getSessionInfo(sessionKey: string): Promise<SessionInfo | null>;
+  /** Check if session is complete. */
+  isSessionComplete(sessionKey: string): Promise<boolean>;
+}
+
+/** Make an HTTP POST request to the Gateway /tools/invoke endpoint. */
+function invokeGateway(
+  url: string,
+  token: string,
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs = 30000,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify({ tool, args });
+    const parsedUrl = new URL(`${url}/tools/invoke`);
+
+    const req = httpRequest(
+      {
+        hostname: parsedUrl.hostname,
+        port: parsedUrl.port,
+        path: parsedUrl.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+          Authorization: `Bearer ${token}`,
+        },
+        timeout: timeoutMs,
+      },
+      (res: IncomingMessage) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(
+              new Error(
+                `Gateway request failed: ${String(res.statusCode)} ${body}`,
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(JSON.parse(body) as unknown);
+          } catch {
+            reject(new Error(`Failed to parse Gateway response: ${body}`));
+          }
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Gateway request timed out'));
+    });
+
+    req.write(payload);
+    req.end();
+  });
+}
+
+/** Create a Gateway client. */
+export function createGatewayClient(
+  options: GatewayClientOptions,
+): GatewayClient {
+  const { url, token, timeoutMs = 30000 } = options;
+
+  return {
+    async spawnSession(
+      task: string,
+      opts?: SpawnSessionOptions,
+    ): Promise<SpawnSessionResult> {
+      const response = (await invokeGateway(
+        url,
+        token,
+        'sessions_spawn',
+        {
+          task,
+          label: opts?.label,
+          thinking: opts?.thinking,
+          runTimeoutSeconds: opts?.runTimeoutSeconds,
+        },
+        timeoutMs,
+      )) as {
+        ok: boolean;
+        result: { details: { childSessionKey: string; runId: string } };
+      };
+
+      if (!response.ok) {
+        throw new Error('Failed to spawn session');
+      }
+
+      return {
+        sessionKey: response.result.details.childSessionKey,
+        runId: response.result.details.runId,
+      };
+    },
+
+    async getSessionHistory(
+      sessionKey: string,
+      limit = 3,
+    ): Promise<SessionMessage[]> {
+      const response = (await invokeGateway(
+        url,
+        token,
+        'sessions_history',
+        { sessionKey, limit, includeTools: false },
+        timeoutMs,
+      )) as { ok: boolean; result: SessionMessage[] };
+
+      if (!response.ok) {
+        throw new Error('Failed to get session history');
+      }
+
+      return response.result;
+    },
+
+    async getSessionInfo(sessionKey: string): Promise<SessionInfo | null> {
+      const response = (await invokeGateway(
+        url,
+        token,
+        'sessions_list',
+        { activeMinutes: 120, limit: 100 },
+        timeoutMs,
+      )) as {
+        ok: boolean;
+        result: Array<{ sessionKey: string } & SessionInfo>;
+      };
+
+      if (!response.ok) {
+        throw new Error('Failed to list sessions');
+      }
+
+      const session = response.result.find((s) => s.sessionKey === sessionKey);
+      if (!session) return null;
+
+      return {
+        totalTokens: session.totalTokens,
+        model: session.model,
+        transcriptPath: session.transcriptPath,
+      };
+    },
+
+    async isSessionComplete(sessionKey: string): Promise<boolean> {
+      const history = await this.getSessionHistory(sessionKey, 3);
+      if (history.length === 0) return false;
+
+      const lastMessage = history[history.length - 1];
+      return (
+        lastMessage.role === 'assistant' && lastMessage.stopReason !== undefined
+      );
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,21 @@ export { executeJob } from './scheduler/executor.js';
 export type { Scheduler, SchedulerDeps } from './scheduler/scheduler.js';
 export { createScheduler } from './scheduler/scheduler.js';
 
+// Gateway
+export type {
+  GatewayClient,
+  GatewayClientOptions,
+  SessionInfo,
+  SessionMessage,
+  SpawnSessionOptions,
+  SpawnSessionResult,
+} from './gateway/client.js';
+export { createGatewayClient } from './gateway/client.js';
+
+// Session executor
+export type { SessionExecutionOptions } from './scheduler/session-executor.js';
+export { executeSession } from './scheduler/session-executor.js';
+
 // Notifier
 export type { Notifier, NotifyConfig } from './notify/slack.js';
 export { createNotifier } from './notify/slack.js';

--- a/src/scheduler/cron-registry.ts
+++ b/src/scheduler/cron-registry.ts
@@ -13,6 +13,7 @@ export interface JobRow {
   name: string;
   schedule: string;
   script: string;
+  type: string;
   timeout_ms: number | null;
   overlap_policy: string;
   on_failure: string | null;

--- a/src/scheduler/scheduler.test.ts
+++ b/src/scheduler/scheduler.test.ts
@@ -66,6 +66,9 @@ function createTestConfig(): RunnerConfig {
       defaultOnFailure: null,
       defaultOnSuccess: null,
     },
+    gateway: {
+      url: 'http://127.0.0.1:18789',
+    },
     log: {
       level: 'info',
     },

--- a/src/scheduler/session-executor.test.ts
+++ b/src/scheduler/session-executor.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for session executor.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GatewayClient } from '../gateway/client.js';
+import { executeSession } from './session-executor.js';
+
+describe('Session executor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('executes a session with raw prompt text', async () => {
+    const mockGateway: GatewayClient = {
+      spawnSession: vi.fn().mockResolvedValue({
+        sessionKey: 'test-key',
+        runId: 'test-run',
+      }),
+      isSessionComplete: vi.fn().mockResolvedValue(true),
+      getSessionInfo: vi.fn().mockResolvedValue({
+        totalTokens: 1200,
+        model: 'claude-sonnet-4',
+      }),
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: 'Generate a daily digest',
+      jobId: 'digest-job',
+      timeoutMs: 60000,
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.tokens).toBe(1200);
+    expect(result.resultMeta).toBe('test-key');
+    // Note: spawnSession call verification omitted due to ESLint unbound-method rule
+  });
+
+  it('rejects script extensions (.js)', async () => {
+    const mockGateway: GatewayClient = {
+      spawnSession: vi.fn(),
+      isSessionComplete: vi.fn(),
+      getSessionInfo: vi.fn(),
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: '/path/to/script.js',
+      jobId: 'legacy-job',
+      timeoutMs: 60000,
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('script extension');
+    // Note: spawnSession not-called verification omitted due to ESLint unbound-method rule
+  });
+
+  it('handles timeout', { timeout: 10000 }, async () => {
+    const mockGateway: GatewayClient = {
+      spawnSession: vi.fn().mockResolvedValue({
+        sessionKey: 'test-key',
+        runId: 'test-run',
+      }),
+      isSessionComplete: vi.fn().mockResolvedValue(false), // Never completes
+      getSessionInfo: vi.fn(),
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: 'Long running task',
+      jobId: 'timeout-job',
+      timeoutMs: 100, // Very short timeout
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('timeout');
+    expect(result.error).toContain('timed out');
+  });
+
+  it('handles spawn error', async () => {
+    const mockGateway: GatewayClient = {
+      spawnSession: vi
+        .fn()
+        .mockRejectedValue(new Error('Gateway connection refused')),
+      isSessionComplete: vi.fn(),
+      getSessionInfo: vi.fn(),
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: 'Test task',
+      jobId: 'error-job',
+      timeoutMs: 60000,
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Gateway connection refused');
+  });
+
+  it('polls with exponential backoff', { timeout: 30000 }, async () => {
+    let callCount = 0;
+    const mockGateway: GatewayClient = {
+      spawnSession: vi.fn().mockResolvedValue({
+        sessionKey: 'test-key',
+        runId: 'test-run',
+      }),
+      isSessionComplete: vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve(callCount >= 3); // Complete after 3 checks
+      }),
+      getSessionInfo: vi.fn().mockResolvedValue({
+        totalTokens: 500,
+        model: 'claude-sonnet-4',
+      }),
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: 'Multi-step task',
+      jobId: 'polling-job',
+      timeoutMs: 60000,
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles missing session info gracefully', async () => {
+    const mockGateway: GatewayClient = {
+      spawnSession: vi.fn().mockResolvedValue({
+        sessionKey: 'test-key',
+        runId: 'test-run',
+      }),
+      isSessionComplete: vi.fn().mockResolvedValue(true),
+      getSessionInfo: vi.fn().mockResolvedValue(null), // Session not found
+      getSessionHistory: vi.fn(),
+    };
+
+    const result = await executeSession({
+      script: 'Ephemeral session',
+      jobId: 'no-info-job',
+      timeoutMs: 60000,
+      gatewayClient: mockGateway,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.tokens).toBe(null); // Gracefully handle missing info
+  });
+});

--- a/src/scheduler/session-executor.ts
+++ b/src/scheduler/session-executor.ts
@@ -1,0 +1,142 @@
+/**
+ * Session executor for job type='session'. Spawns OpenClaw Gateway sessions and polls for completion.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { extname } from 'node:path';
+
+import type { GatewayClient } from '../gateway/client.js';
+import type { ExecutionResult } from './executor.js';
+
+/** Options for executing a session job. */
+export interface SessionExecutionOptions {
+  /** Script field from job: can be raw prompt, path to .md/.txt, or legacy .js dispatcher. */
+  script: string;
+  /** Job identifier (used as session label). */
+  jobId: string;
+  /** Optional execution timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Gateway client instance. */
+  gatewayClient: GatewayClient;
+}
+
+/** File extensions that indicate a script rather than a prompt. */
+const SCRIPT_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ps1', '.cmd', '.bat'];
+
+/** Resolve task prompt from script field: read file if .md/.txt, return raw text otherwise. */
+function resolveTaskPrompt(script: string): string | null {
+  const ext = extname(script).toLowerCase();
+
+  // If script extension, caller should fall back to script executor
+  if (SCRIPT_EXTENSIONS.includes(ext)) {
+    return null;
+  }
+
+  // If .md or .txt, read file contents
+  if (ext === '.md' || ext === '.txt') {
+    if (!existsSync(script)) {
+      throw new Error(`Prompt file not found: ${script}`);
+    }
+    return readFileSync(script, 'utf-8');
+  }
+
+  // Otherwise, treat script as raw prompt text
+  return script;
+}
+
+/** Poll for session completion with exponential backoff (capped). */
+async function pollCompletion(
+  gatewayClient: GatewayClient,
+  sessionKey: string,
+  timeoutMs: number,
+): Promise<void> {
+  const startTime = Date.now();
+  let interval = 5000; // Start at 5s
+  const maxInterval = 15000;
+
+  while (Date.now() - startTime < timeoutMs) {
+    const isComplete = await gatewayClient.isSessionComplete(sessionKey);
+    if (isComplete) return;
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+    interval = Math.min(interval * 1.2, maxInterval); // Exponential backoff capped
+  }
+
+  throw new Error(`Session timed out after ${String(timeoutMs)}ms`);
+}
+
+/**
+ * Execute a session job: spawn a Gateway session, poll for completion, fetch token usage.
+ */
+export async function executeSession(
+  options: SessionExecutionOptions,
+): Promise<ExecutionResult> {
+  const { script, jobId, timeoutMs = 300000, gatewayClient } = options;
+  const startTime = Date.now();
+
+  try {
+    // Resolve task prompt
+    const taskPrompt = resolveTaskPrompt(script);
+    if (taskPrompt === null) {
+      throw new Error(
+        'Session job script has script extension; expected prompt text or .md/.txt file',
+      );
+    }
+
+    // Spawn session
+    const { sessionKey } = await gatewayClient.spawnSession(taskPrompt, {
+      label: jobId,
+      thinking: 'low',
+      runTimeoutSeconds: Math.floor(timeoutMs / 1000),
+    });
+
+    // Poll for completion
+    await pollCompletion(gatewayClient, sessionKey, timeoutMs);
+
+    // Fetch session info for token count
+    const sessionInfo = await gatewayClient.getSessionInfo(sessionKey);
+    const tokens = sessionInfo?.totalTokens ?? null;
+
+    const durationMs = Date.now() - startTime;
+
+    return {
+      status: 'ok',
+      exitCode: null,
+      durationMs,
+      tokens,
+      resultMeta: sessionKey,
+      stdoutTail: `Session completed: ${sessionKey}`,
+      stderrTail: '',
+      error: null,
+    };
+  } catch (err: unknown) {
+    const durationMs = Date.now() - startTime;
+    const errorMessage =
+      err instanceof Error ? err.message : 'Unknown session error';
+
+    // Check if timeout
+    if (errorMessage.includes('timed out')) {
+      return {
+        status: 'timeout',
+        exitCode: null,
+        durationMs,
+        tokens: null,
+        resultMeta: null,
+        stdoutTail: '',
+        stderrTail: errorMessage,
+        error: errorMessage,
+      };
+    }
+
+    return {
+      status: 'error',
+      exitCode: null,
+      durationMs,
+      tokens: null,
+      resultMeta: null,
+      stdoutTail: '',
+      stderrTail: errorMessage,
+      error: errorMessage,
+    };
+  }
+}

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -26,6 +26,14 @@ const logSchema = z.object({
   file: z.string().optional(),
 });
 
+/** Gateway configuration sub-schema. */
+const gatewaySchema = z.object({
+  /** OpenClaw Gateway URL. */
+  url: z.string().default('http://127.0.0.1:18789'),
+  /** Path to file containing Gateway auth token. */
+  tokenPath: z.string().optional(),
+});
+
 /** Full runner configuration schema. Validates and provides defaults. */
 export const runnerConfigSchema = z.object({
   /** HTTP server port for the runner API. */
@@ -49,6 +57,8 @@ export const runnerConfigSchema = z.object({
   }),
   /** Logging configuration. */
   log: logSchema.default({ level: 'info' }),
+  /** Gateway configuration for session-type jobs. */
+  gateway: gatewaySchema.default({ url: 'http://127.0.0.1:18789' }),
 });
 
 /** Inferred runner configuration type. */


### PR DESCRIPTION
Phase 5: Native session dispatch for session-type jobs.

## Changes
- **Gateway client** (`src/gateway/client.ts`): HTTP client wrapping `/tools/invoke` for spawn/poll/info
- **Session executor** (`src/scheduler/session-executor.ts`): resolves prompt (raw text, .md/.txt file, or fallback), spawns session, polls completion, collects token usage
- **Config schema**: `gateway.url` + `gateway.tokenPath` fields (optional, graceful degradation)
- **Scheduler routing**: session-type jobs → session executor; script-type → existing executor
- **Backward compat**: .js/.ps1/.cmd scripts in session jobs still use script executor
- **Public API exports** for all new types

## Testing
- Gateway client: structure + creation tests
- Session executor: raw prompt, script rejection, timeout, spawn error, polling, missing info
- All existing tests pass
- STAN all green (docs warning is pre-existing)