### PR TITLE
chore: change default port from 3100 to 1937

### DIFF
--- a/src/scheduler/scheduler.test.ts
+++ b/src/scheduler/scheduler.test.ts
@@ -55,7 +55,7 @@ vi.mock('croner', async () => {
 
 function createTestConfig(): RunnerConfig {
   return {
-    port: 3100,
+    port: 1937,
     dbPath: ':memory:',
     maxConcurrency: 5,
     runRetentionDays: 30,

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -37,7 +37,7 @@ const gatewaySchema = z.object({
 /** Full runner configuration schema. Validates and provides defaults. */
 export const runnerConfigSchema = z.object({
   /** HTTP server port for the runner API. */
-  port: z.number().default(3100),
+  port: z.number().default(1937),
   /** Path to SQLite database file. */
   dbPath: z.string().default('./data/runner.sqlite'),
   /** Maximum number of concurrent job executions. */


### PR DESCRIPTION
Part of the 1930s port namespace migration.

| Service | Port |
|---------|------|
| jeeves-server | 1934 |
| jeeves-watcher | 1936 |
| jeeves-runner | 1937 |

Changes: default port in config schema (3100 → 1937) and test fixture.
Tests: 109/109 pass (3 pre-existing CLI integration failures on main, unrelated).