### PR TITLE
fix: add PRAGMA busy_timeout=5000 to prevent SQLITE_BUSY errors

### DIFF
--- a/packages/service/src/db/connection.ts
+++ b/packages/service/src/db/connection.ts
@@ -22,6 +22,10 @@ export function createConnection(dbPath: string): DatabaseSync {
   db.exec('PRAGMA journal_mode = WAL;');
   db.exec('PRAGMA foreign_keys = ON;');
 
+  // Wait up to 5s for write lock instead of failing immediately (SQLITE_BUSY).
+  // Multiple runner child processes share this DB file concurrently.
+  db.exec('PRAGMA busy_timeout = 5000;');
+
   return db;
 }
 


### PR DESCRIPTION
## Problem

Multiple runner child processes open separate connections to the same SQLite file. Without \usy_timeout\, concurrent writes throw immediately with \database is locked\ (SQLITE_BUSY, errcode 5) instead of waiting for the lock to clear.

Observed in production: \Sync GH Issues\ and \Poll Email\ jobs failing on \client.setItem()\ when another job holds the write lock.

## Fix

Add \PRAGMA busy_timeout = 5000\ to \createConnection()\ in \connection.ts\. This gives concurrent writers up to 5 seconds to acquire the write lock before failing.

WAL mode was already enabled but busy_timeout was 0 (the SQLite default).

## Tests

All 92 tests passing (83 service + 9 plugin).

## Long-term

v0.4.0 graph architecture eliminates this class of bug by design: the runner process becomes the sole DB writer, and edge scripts return results via stdout rather than writing to SQLite directly.