### PR TITLE
chore: adopt @karmaniverous/jeeves ^0.2.0 core SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,14 +1568,14 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.1.6.tgz",
-      "integrity": "sha512-PTYByPH9583Vh/jIa2UquAc8uLuauCmVC5zpTS07oaxU4CvXInEbTLw6N7q9+JSoUVukWeftJjohKoT7wkmVQg==",
-      "dev": true,
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.2.0.tgz",
+      "integrity": "sha512-o3wM1h04ayoaXs6hB1dYklqsEm/stM43e67zdEosUqkAiFwCLuOPwodB2bDaklZpYGxb9hcpPnF6rRyaMFwpPA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.2",
         "handlebars": "^4.7.8",
+        "jsonpath-plus": "^10.4.0",
         "package-directory": "^8.2.0",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.7.2",
@@ -1600,7 +1600,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -4901,7 +4900,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
       "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5235,14 +5233,12 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -6425,7 +6421,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6485,8 +6480,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -6886,7 +6880,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.2.0.tgz",
       "integrity": "sha512-qJSu5Mo6tHmRxCy2KCYYKYgcfBdUpy9dwReaZD/xwf608AUk/MoRtIOWzgDtUeGeC7n/55yC3MI1Q+MbSoektw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up-simple": "^1.0.0"
@@ -7185,7 +7178,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7197,7 +7189,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7207,7 +7198,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/protocols": {
@@ -7870,7 +7860,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8254,7 +8243,6 @@
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -8564,8 +8552,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -8706,7 +8693,7 @@
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.52.0",
-        "@karmaniverous/jeeves": "^0.1.6",
+        "@karmaniverous/jeeves": "^0.2.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -8729,6 +8716,7 @@
       "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@karmaniverous/jeeves": "^0.2.0",
         "commander": "^14.0.3",
         "croner": "^10.0.1",
         "fastify": "^5.7.4",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.52.0",
-    "@karmaniverous/jeeves": "^0.1.6",
+    "@karmaniverous/jeeves": "^0.2.0",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/openclaw/rollup.config.ts
+++ b/packages/openclaw/rollup.config.ts
@@ -40,25 +40,19 @@ const pluginConfig: RollupOptions = {
 
 const cliConfig: RollupOptions = {
   input: 'src/cli.ts',
-  external: [
-    'fs',
-    'path',
-    'os',
-    'url',
-    'node:fs',
-    'node:path',
-    'node:os',
-    'node:url',
-  ],
+  external: [/^node:/],
   output: {
     file: 'dist/cli.js',
     format: 'esm',
     banner: '#!/usr/bin/env node',
   },
   plugins: [
+    resolve({ preferBuiltins: true }),
+    commonjs(),
     typescriptPlugin({
       tsconfig: './tsconfig.json',
       outputToFilesystem: false,
+      outDir: 'dist',
       noEmit: false,
       declaration: false,
       incremental: false,

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -12,6 +12,8 @@
  *   - OPENCLAW_CONFIG env var (path to openclaw.json)
  *   - OPENCLAW_HOME env var (path to .openclaw directory)
  *   - Default: ~/.openclaw/openclaw.json
+ *
+ * @module cli
  */
 
 import {
@@ -21,31 +23,18 @@ import {
   readFileSync,
   rmSync,
   writeFileSync,
-} from 'fs';
-import { homedir } from 'os';
-import { dirname, join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const PLUGIN_ID = 'jeeves-runner-openclaw';
+import {
+  patchConfig,
+  removeManagedSection,
+  resolveConfigPath,
+  resolveOpenClawHome,
+} from '@karmaniverous/jeeves';
 
-/** Resolve the OpenClaw home directory. */
-function resolveOpenClawHome(): string {
-  if (process.env.OPENCLAW_CONFIG) {
-    return dirname(resolve(process.env.OPENCLAW_CONFIG));
-  }
-  if (process.env.OPENCLAW_HOME) {
-    return resolve(process.env.OPENCLAW_HOME);
-  }
-  return join(homedir(), '.openclaw');
-}
-
-/** Resolve the config file path. */
-function resolveConfigPath(home: string): string {
-  if (process.env.OPENCLAW_CONFIG) {
-    return resolve(process.env.OPENCLAW_CONFIG);
-  }
-  return join(home, 'openclaw.json');
-}
+import { PLUGIN_ID } from './constants.js';
 
 /** Get the package root (where this CLI lives). */
 function getPackageRoot(): string {
@@ -65,75 +54,6 @@ function readJson(path: string): Record<string, unknown> | null {
 /** Write JSON with 2-space indent + trailing newline. */
 function writeJson(path: string, data: unknown): void {
   writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
-}
-
-/**
- * Patch an allowlist array: add or remove the plugin ID.
- * Returns a log message if a change was made, or undefined.
- */
-function patchAllowList(
-  parent: Record<string, unknown>,
-  key: string,
-  label: string,
-  mode: 'add' | 'remove',
-): string | undefined {
-  if (!Array.isArray(parent[key]) || (parent[key] as unknown[]).length === 0)
-    return undefined;
-
-  const list = parent[key] as string[];
-  if (mode === 'add') {
-    if (!list.includes(PLUGIN_ID)) {
-      list.push(PLUGIN_ID);
-      return `Added "${PLUGIN_ID}" to ${label}`;
-    }
-  } else {
-    const filtered = list.filter((id) => id !== PLUGIN_ID);
-    if (filtered.length !== list.length) {
-      parent[key] = filtered;
-      return `Removed "${PLUGIN_ID}" from ${label}`;
-    }
-  }
-  return undefined;
-}
-
-/** Patch OpenClaw config for install or uninstall. Returns log messages. */
-export function patchConfig(
-  config: Record<string, unknown>,
-  mode: 'add' | 'remove',
-): string[] {
-  const messages: string[] = [];
-
-  // Ensure plugins section
-  if (!config.plugins || typeof config.plugins !== 'object') {
-    config.plugins = {};
-  }
-  const plugins = config.plugins as Record<string, unknown>;
-
-  // plugins.allow
-  const pluginAllow = patchAllowList(plugins, 'allow', 'plugins.allow', mode);
-  if (pluginAllow) messages.push(pluginAllow);
-
-  // plugins.entries
-  if (!plugins.entries || typeof plugins.entries !== 'object') {
-    plugins.entries = {};
-  }
-  const entries = plugins.entries as Record<string, unknown>;
-  if (mode === 'add') {
-    if (!entries[PLUGIN_ID]) {
-      entries[PLUGIN_ID] = { enabled: true };
-      messages.push(`Added "${PLUGIN_ID}" to plugins.entries`);
-    }
-  } else if (PLUGIN_ID in entries) {
-    Reflect.deleteProperty(entries, PLUGIN_ID);
-    messages.push(`Removed "${PLUGIN_ID}" from plugins.entries`);
-  }
-
-  // tools.allow
-  const tools = (config.tools ?? {}) as Record<string, unknown>;
-  const toolAllow = patchAllowList(tools, 'allow', 'tools.allow', mode);
-  if (toolAllow) messages.push(toolAllow);
-
-  return messages;
 }
 
 /** Install the plugin into OpenClaw's extensions directory. */
@@ -185,14 +105,14 @@ function install(): void {
     const dest = join(extDir, file);
     if (existsSync(src)) {
       cpSync(src, dest, { recursive: true });
-      console.log(`  ✓ ${file}`);
+      console.log(`  \u2713 ${file}`);
     }
   }
 
   const nodeModulesSrc = join(pkgRoot, 'node_modules');
   if (existsSync(nodeModulesSrc)) {
     cpSync(nodeModulesSrc, join(extDir, 'node_modules'), { recursive: true });
-    console.log('  ✓ node_modules');
+    console.log('  \u2713 node_modules');
   }
 
   // Patch config
@@ -204,18 +124,18 @@ function install(): void {
     process.exit(1);
   }
 
-  for (const msg of patchConfig(config, 'add')) {
-    console.log(`  ✓ ${msg}`);
+  for (const msg of patchConfig(config, PLUGIN_ID, 'add')) {
+    console.log(`  \u2713 ${msg}`);
   }
   writeJson(configPath, config);
 
   console.log();
-  console.log('✅ Plugin installed successfully.');
+  console.log('\u2705 Plugin installed successfully.');
   console.log('   Restart the OpenClaw gateway to load the plugin.');
 }
 
 /** Uninstall the plugin from OpenClaw's extensions directory. */
-function uninstall(): void {
+async function uninstall(): Promise<void> {
   const home = resolveOpenClawHome();
   const configPath = resolveConfigPath(home);
   const extDir = join(home, 'extensions', PLUGIN_ID);
@@ -227,24 +147,33 @@ function uninstall(): void {
 
   if (existsSync(extDir)) {
     rmSync(extDir, { recursive: true, force: true });
-    console.log(`✓ Removed ${extDir}`);
+    console.log(`\u2713 Removed ${extDir}`);
   } else {
-    console.log(`  (extensions directory not found, skipping)`);
+    console.log('  (extensions directory not found, skipping)');
   }
 
   if (existsSync(configPath)) {
     console.log('Patching OpenClaw config...');
     const config = readJson(configPath);
     if (config) {
-      for (const msg of patchConfig(config, 'remove')) {
-        console.log(`  ✓ ${msg}`);
+      for (const msg of patchConfig(config, PLUGIN_ID, 'remove')) {
+        console.log(`  \u2713 ${msg}`);
       }
       writeJson(configPath, config);
     }
   }
 
+  // Remove managed TOOLS.md section
+  const workspacePath = process.cwd();
+  const toolsPath = join(workspacePath, 'TOOLS.md');
+  if (existsSync(toolsPath)) {
+    console.log('Removing managed TOOLS.md section...');
+    await removeManagedSection(toolsPath, { sectionId: 'Runner' });
+    console.log('  \u2713 Removed Runner section from TOOLS.md');
+  }
+
   console.log();
-  console.log('✅ Plugin uninstalled successfully.');
+  console.log('\u2705 Plugin uninstalled successfully.');
   console.log('   Restart the OpenClaw gateway to complete removal.');
 }
 
@@ -256,11 +185,11 @@ switch (command) {
     install();
     break;
   case 'uninstall':
-    uninstall();
+    void uninstall();
     break;
   default:
     console.log(
-      `@karmaniverous/jeeves-runner-openclaw — OpenClaw plugin installer`,
+      `@karmaniverous/jeeves-runner-openclaw \u2014 OpenClaw plugin installer`,
     );
     console.log();
     console.log('Usage:');

--- a/packages/openclaw/src/constants.ts
+++ b/packages/openclaw/src/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared constants for the jeeves-runner OpenClaw plugin.
+ *
+ * @module constants
+ */
+
+/** Plugin identifier used for config resolution and error guidance. */
+export const PLUGIN_ID = 'jeeves-runner-openclaw';

--- a/packages/openclaw/src/generateContent.ts
+++ b/packages/openclaw/src/generateContent.ts
@@ -1,9 +1,10 @@
 /**
- * @module plugin/generateContent
  * Generates the runner's TOOLS.md section content by querying the runner API.
+ *
+ * @module generateContent
  */
 
-import { fetchJson } from './helpers.js';
+import { fetchJson } from '@karmaniverous/jeeves';
 
 /** Stats response from GET /stats. */
 interface RunnerStats {

--- a/packages/openclaw/src/helpers.test.ts
+++ b/packages/openclaw/src/helpers.test.ts
@@ -1,13 +1,12 @@
 /**
- * Tests for plugin helpers. Focuses on logic with branching:
- * config resolution and connection error classification.
- *
- * ok() and fail() are trivial formatters tested implicitly by runnerTools.test.ts.
+ * Tests for plugin helpers. Validates getApiUrl and getConfigRoot resolve
+ * via plugin config, environment, and defaults.
  */
 
+import { type PluginApi } from '@karmaniverous/jeeves';
 import { describe, expect, it } from 'vitest';
 
-import { connectionFail, getApiUrl, type PluginApi } from './helpers.js';
+import { getApiUrl, getConfigRoot } from './helpers.js';
 
 describe('getApiUrl', () => {
   it('returns default URL when no config', () => {
@@ -32,23 +31,25 @@ describe('getApiUrl', () => {
   });
 });
 
-describe('connectionFail', () => {
-  it('returns actionable message for ECONNREFUSED', () => {
-    const err = new TypeError('fetch failed');
-    Object.defineProperty(err, 'cause', {
-      value: { code: 'ECONNREFUSED' },
-    });
-    const result = connectionFail(err, 'http://localhost:1937');
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('not reachable');
+describe('getConfigRoot', () => {
+  it('returns default config root when no config', () => {
+    const api: PluginApi = { registerTool: () => {} };
+    expect(getConfigRoot(api)).toBe('j:/config');
   });
 
-  it('falls back to generic error for non-connection errors', () => {
-    const result = connectionFail(
-      new Error('bad request'),
-      'http://localhost:1937',
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toBe('Error: bad request');
+  it('returns configured config root', () => {
+    const api: PluginApi = {
+      config: {
+        plugins: {
+          entries: {
+            'jeeves-runner-openclaw': {
+              config: { configRoot: '/custom/config' },
+            },
+          },
+        },
+      },
+      registerTool: () => {},
+    };
+    expect(getConfigRoot(api)).toBe('/custom/config');
   });
 });

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -1,114 +1,31 @@
 /**
- * @module plugin/helpers
- * Shared types and utility functions for the OpenClaw plugin tool registrations.
+ * Runner-specific convenience wrappers over `@karmaniverous/jeeves` core SDK.
+ *
+ * @module helpers
  */
 
-/** Minimal OpenClaw plugin API surface used for tool registration. */
-export interface PluginApi {
-  config?: {
-    agents?: { defaults?: { workspace?: string } };
-    plugins?: {
-      entries?: Record<string, { config?: Record<string, unknown> }>;
-    };
-  };
-  registerTool(
-    tool: {
-      name: string;
-      description: string;
-      parameters: Record<string, unknown>;
-      execute: (
-        id: string,
-        params: Record<string, unknown>,
-      ) => Promise<ToolResult>;
-    },
-    options?: { optional?: boolean },
-  ): void;
-}
+import { type PluginApi, resolvePluginSetting } from '@karmaniverous/jeeves';
 
-/** Result shape returned by each tool execution. */
-export interface ToolResult {
-  content: Array<{ type: string; text: string }>;
-  isError?: boolean;
-}
+import { PLUGIN_ID } from './constants.js';
 
-const DEFAULT_API_URL = 'http://127.0.0.1:1937';
-
-/** Plugin identifier used for config lookups and error messages. */
-export const PLUGIN_ID = 'jeeves-runner-openclaw';
-
-/** Get a plugin config value by key. */
-export function getPluginConfig(api: PluginApi, key: string): unknown {
-  return api.config?.plugins?.entries?.[PLUGIN_ID]?.config?.[key];
-}
-
-/** Resolve the runner API base URL from plugin config. */
+/** Resolve the runner API base URL. */
 export function getApiUrl(api: PluginApi): string {
-  const url = getPluginConfig(api, 'apiUrl');
-  return typeof url === 'string' ? url : DEFAULT_API_URL;
+  return resolvePluginSetting(
+    api,
+    PLUGIN_ID,
+    'apiUrl',
+    'JEEVES_RUNNER_URL',
+    'http://127.0.0.1:1937',
+  );
 }
 
-/** Format a successful tool result. */
-export function ok(data: unknown): ToolResult {
-  return {
-    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
-  };
-}
-
-/** Format an error tool result. */
-export function fail(error: unknown): ToolResult {
-  const message = error instanceof Error ? error.message : String(error);
-  return {
-    content: [{ type: 'text', text: `Error: ${message}` }],
-    isError: true,
-  };
-}
-
-/** Format a connection error with actionable guidance. */
-export function connectionFail(error: unknown, baseUrl: string): ToolResult {
-  const cause = error instanceof Error ? error.cause : undefined;
-  const code =
-    cause && typeof cause === 'object' && 'code' in cause
-      ? String(cause.code)
-      : '';
-  const isConnectionError =
-    code === 'ECONNREFUSED' || code === 'ENOTFOUND' || code === 'ETIMEDOUT';
-
-  if (isConnectionError) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: [
-            `Runner service not reachable at ${baseUrl}.`,
-            'Either start the runner service, or if it runs on a different port,',
-            `set plugins.entries.${PLUGIN_ID}.config.apiUrl in openclaw.json.`,
-          ].join('\n'),
-        },
-      ],
-      isError: true,
-    };
-  }
-
-  return fail(error);
-}
-
-/** Fetch JSON from a URL, throwing on non-OK responses. */
-export async function fetchJson(
-  url: string,
-  init?: RequestInit,
-): Promise<unknown> {
-  const res = await fetch(url, init);
-  if (!res.ok) {
-    throw new Error(`HTTP ${String(res.status)}: ${await res.text()}`);
-  }
-  return res.json();
-}
-
-/** POST JSON to a URL and return parsed response. */
-export async function postJson(url: string, body: unknown): Promise<unknown> {
-  return fetchJson(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+/** Resolve the platform config root. */
+export function getConfigRoot(api: PluginApi): string {
+  return resolvePluginSetting(
+    api,
+    PLUGIN_ID,
+    'configRoot',
+    'JEEVES_CONFIG_ROOT',
+    'j:/config',
+  );
 }

--- a/packages/openclaw/src/index.test.ts
+++ b/packages/openclaw/src/index.test.ts
@@ -1,10 +1,9 @@
 /**
- * @module plugin/index.test
+ * @module index.test
  */
 
+import { type PluginApi } from '@karmaniverous/jeeves';
 import { describe, expect, it, vi } from 'vitest';
-
-import type { PluginApi } from './helpers.js';
 
 type MockFn = ReturnType<typeof vi.fn>;
 
@@ -13,6 +12,33 @@ vi.mock('@karmaniverous/jeeves', () => {
     init: vi.fn(),
     SECTION_IDS: { Runner: 'Runner' },
     resolveWorkspacePath: vi.fn(() => '/mock/workspace'),
+    resolvePluginSetting: vi.fn(
+      (
+        _api: unknown,
+        _pluginId: string,
+        key: string,
+        _envVar: string,
+        fallback: string,
+      ) => {
+        if (key === 'apiUrl') {
+          const api = _api as PluginApi;
+          const val =
+            api.config?.plugins?.entries?.['jeeves-runner-openclaw']?.config?.[
+              key
+            ];
+          return typeof val === 'string' ? val : fallback;
+        }
+        if (key === 'configRoot') {
+          const api = _api as PluginApi;
+          const val =
+            api.config?.plugins?.entries?.['jeeves-runner-openclaw']?.config?.[
+              key
+            ];
+          return typeof val === 'string' ? val : fallback;
+        }
+        return fallback;
+      },
+    ),
     createAsyncContentCache: vi.fn(() => vi.fn(() => 'cached content')),
     createComponentWriter: vi.fn(() => ({ start: vi.fn() })),
   };
@@ -45,7 +71,7 @@ describe('plugin register', () => {
     expect(writer.start).toHaveBeenCalled();
   });
 
-  it('uses configRoot from plugin config when api.getConfig unavailable', async () => {
+  it('uses configRoot from plugin config', async () => {
     const { default: register } = await import('./index.js');
     const core = (await import('@karmaniverous/jeeves')) as unknown as {
       init: MockFn;

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -1,68 +1,66 @@
 /**
- * @module plugin
- * OpenClaw plugin entry point. Registers runner tools and keeps TOOLS.md in sync.
+ * OpenClaw plugin for jeeves-runner.
+ *
+ * Thin HTTP client — all operations delegate to the jeeves-runner service.
+ * Uses `@karmaniverous/jeeves` core for TOOLS.md and platform content.
+ *
+ * @packageDocumentation
  */
 
-import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
   createAsyncContentCache,
   createComponentWriter,
   init,
-  type JeevesComponent,
+  type PluginApi,
   resolveWorkspacePath,
   SECTION_IDS,
 } from '@karmaniverous/jeeves';
 
 import { generateRunnerContent } from './generateContent.js';
-import type { PluginApi } from './helpers.js';
-import { getApiUrl, getPluginConfig } from './helpers.js';
+import { getApiUrl, getConfigRoot } from './helpers.js';
 import { registerRunnerTools } from './runnerTools.js';
 import {
   createRunnerPluginCommands,
   createRunnerServiceCommands,
 } from './serviceCommands.js';
 
-const require = createRequire(import.meta.url);
-const pkg = require(
-  join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'),
-) as { version: string };
+/** Plugin version derived from package.json. */
+const PLUGIN_VERSION: string = (() => {
+  try {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(resolve(dir, '..', 'package.json'), 'utf8'),
+    ) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
 
-const DEFAULT_CONFIG_ROOT = 'j:/config';
 const REFRESH_INTERVAL_SECONDS = 67;
-const COMPONENT_NAME = 'runner';
-const COMPONENT_VERSION = pkg.version;
 
 /** Register all runner tools with the OpenClaw plugin API and start TOOLS.md writer. */
 export default function register(api: PluginApi): void {
   const baseUrl = getApiUrl(api);
   registerRunnerTools(api, baseUrl);
 
-  // Initialize core paths
-  const workspacePath = resolveWorkspacePath(api);
-  const getConfig = (api as unknown as { getConfig?: (key: string) => unknown })
-    .getConfig;
-  const configRootRaw =
-    (typeof getConfig === 'function' ? getConfig('configRoot') : undefined) ??
-    getPluginConfig(api, 'configRoot');
-  const configRoot =
-    typeof configRootRaw === 'string' && configRootRaw.trim().length > 0
-      ? configRootRaw
-      : DEFAULT_CONFIG_ROOT;
+  init({
+    workspacePath: resolveWorkspacePath(api),
+    configRoot: getConfigRoot(api),
+  });
 
-  init({ workspacePath, configRoot });
-
-  // Synchronous generator backed by async cache from core
   const getContent = createAsyncContentCache({
     fetch: async () => generateRunnerContent(baseUrl),
     placeholder: '> Initializing runner status...',
   });
 
-  const component: JeevesComponent = {
-    name: COMPONENT_NAME,
-    version: COMPONENT_VERSION,
+  const writer = createComponentWriter({
+    name: 'runner',
+    version: PLUGIN_VERSION,
     sectionId: SECTION_IDS.Runner,
     refreshIntervalSeconds: REFRESH_INTERVAL_SECONDS,
     generateToolsContent: getContent,
@@ -70,8 +68,7 @@ export default function register(api: PluginApi): void {
     pluginPackage: '@karmaniverous/jeeves-runner-openclaw',
     serviceCommands: createRunnerServiceCommands(baseUrl),
     pluginCommands: createRunnerPluginCommands(),
-  };
+  });
 
-  const writer = createComponentWriter(component);
   writer.start();
 }

--- a/packages/openclaw/src/runnerTools.test.ts
+++ b/packages/openclaw/src/runnerTools.test.ts
@@ -2,9 +2,9 @@
  * Tests for runner tool registrations.
  */
 
+import { type PluginApi, type ToolResult } from '@karmaniverous/jeeves';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { PluginApi, ToolResult } from './helpers.js';
 import { registerRunnerTools } from './runnerTools.js';
 
 /** Create a mock PluginApi that captures registered tools. */

--- a/packages/openclaw/src/runnerTools.ts
+++ b/packages/openclaw/src/runnerTools.ts
@@ -1,6 +1,7 @@
 /**
- * @module plugin/runnerTools
  * Runner tool registrations (runner_* tools) for the OpenClaw plugin.
+ *
+ * @module runnerTools
  */
 
 import {
@@ -10,7 +11,9 @@ import {
   type PluginApi,
   postJson,
   type ToolResult,
-} from './helpers.js';
+} from '@karmaniverous/jeeves';
+
+import { PLUGIN_ID } from './constants.js';
 
 /** Config for a runner API tool. */
 interface ApiToolConfig {
@@ -45,7 +48,7 @@ function registerApiTool(
               : await fetchJson(url);
           return ok(data);
         } catch (error) {
-          return connectionFail(error, baseUrl);
+          return connectionFail(error, baseUrl, PLUGIN_ID);
         }
       },
     },
@@ -61,6 +64,11 @@ const JOB_ID_PARAM = {
   },
   required: ['jobId'],
 } as const;
+
+/** URL-encode the jobId param for safe path interpolation. */
+function jobPath(params: Record<string, unknown>, suffix = ''): string {
+  return `/jobs/${encodeURIComponent(String(params.jobId))}${suffix}`;
+}
 
 /** Register all 7 runner_* tools with the OpenClaw plugin API. */
 export function registerRunnerTools(api: PluginApi, baseUrl: string): void {
@@ -84,10 +92,7 @@ export function registerRunnerTools(api: PluginApi, baseUrl: string): void {
       description:
         'Manually trigger a runner job. Blocks until the job completes and returns the run result.',
       parameters: JOB_ID_PARAM,
-      buildRequest: (params) => [
-        `/jobs/${encodeURIComponent(String(params.jobId))}/run`,
-        {},
-      ],
+      buildRequest: (params) => [jobPath(params, '/run'), {}],
     },
     {
       name: 'runner_runs',
@@ -104,13 +109,11 @@ export function registerRunnerTools(api: PluginApi, baseUrl: string): void {
         },
       },
       buildRequest: (params) => {
-        const limit =
+        const query =
           params.limit !== undefined
             ? `?limit=${String(Number(params.limit))}`
             : '';
-        return [
-          `/jobs/${encodeURIComponent(String(params.jobId))}/runs${limit}`,
-        ];
+        return [jobPath(params, `/runs${query}`)];
       },
     },
     {
@@ -118,28 +121,20 @@ export function registerRunnerTools(api: PluginApi, baseUrl: string): void {
       description:
         'Get full configuration details for a single runner job, including script path, schedule, timeout, and overlap policy.',
       parameters: JOB_ID_PARAM,
-      buildRequest: (params) => [
-        `/jobs/${encodeURIComponent(String(params.jobId))}`,
-      ],
+      buildRequest: (params) => [jobPath(params)],
     },
     {
       name: 'runner_enable',
       description: 'Enable a disabled runner job. Takes effect immediately.',
       parameters: JOB_ID_PARAM,
-      buildRequest: (params) => [
-        `/jobs/${encodeURIComponent(String(params.jobId))}/enable`,
-        {},
-      ],
+      buildRequest: (params) => [jobPath(params, '/enable'), {}],
     },
     {
       name: 'runner_disable',
       description:
         'Disable a runner job. The job will not run until re-enabled. Takes effect immediately.',
       parameters: JOB_ID_PARAM,
-      buildRequest: (params) => [
-        `/jobs/${encodeURIComponent(String(params.jobId))}/disable`,
-        {},
-      ],
+      buildRequest: (params) => [jobPath(params, '/disable'), {}],
     },
   ];
 

--- a/packages/openclaw/src/serviceCommands.ts
+++ b/packages/openclaw/src/serviceCommands.ts
@@ -1,15 +1,15 @@
 /**
- * @module plugin/serviceCommands
  * Service and plugin lifecycle commands for the runner component.
+ *
+ * @module serviceCommands
  */
 
-import type {
-  PluginCommands,
-  ServiceCommands,
-  ServiceStatus,
+import {
+  fetchJson,
+  type PluginCommands,
+  type ServiceCommands,
+  type ServiceStatus,
 } from '@karmaniverous/jeeves';
-
-import { fetchJson } from './helpers.js';
 
 /** Health response from GET /health. */
 interface HealthResponse {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -46,6 +46,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@karmaniverous/jeeves": "^0.2.0",
     "commander": "^14.0.3",
     "croner": "^10.0.1",
     "fastify": "^5.7.4",
@@ -75,7 +76,7 @@
     "vitest": "^4.0.18"
   },
   "scripts": {
-    "build": "rimraf dist && cross-env NO_COLOR=1 rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
+    "build": "rimraf dist && cross-env NO_COLOR=1 rollup --config rollup.config.mjs",
     "changelog": "auto-changelog",
     "diagrams": "cd diagrams && plantuml -tpng -o ../assets -r .",
     "knip": "knip",
@@ -83,7 +84,7 @@
     "lint:fix": "eslint --fix .",
     "release": "dotenvx run -f .env.local -- release-it",
     "release:pre": "dotenvx run -f .env.local -- release-it --no-git.requireBranch --github.prerelease --preRelease",
-    "test": "vitest run",
+    "test": "npm run build && vitest run",
     "typecheck": "tsc"
   },
   "auto-changelog": {

--- a/packages/service/rollup.config.mjs
+++ b/packages/service/rollup.config.mjs
@@ -1,33 +1,49 @@
+/**
+ * Rollup configuration for the jeeves-runner service package.
+ * Builds:
+ * - ESM library output (dist/mjs)
+ * - bundled type definitions (dist/index.d.ts)
+ * - CLI commands (dist/cli/*)
+ *
+ * Authored as ESM JavaScript to avoid Rollup config-plugin TypeScript warnings.
+ *
+ * @module rollup.config
+ */
+
 import { createRequire } from 'node:module';
 
-import aliasPlugin, { type Alias } from '@rollup/plugin-alias';
+/**
+ * Minimal package.json shape used by this config.
+ *
+ * @typedef {{
+ *   dependencies?: Record<string, string>,
+ *   peerDependencies?: Record<string, string>
+ * }} PackageJson
+ */
+
+import aliasPlugin from '@rollup/plugin-alias';
 import commonjsPlugin from '@rollup/plugin-commonjs';
 import jsonPlugin from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import fs from 'fs-extra';
-import type { InputOptions, RollupOptions } from 'rollup';
 import copyPlugin from 'rollup-plugin-copy';
 import dtsPlugin from 'rollup-plugin-dts';
 
 const require = createRequire(import.meta.url);
-type Package = Record<string, Record<string, string> | undefined>;
-const pkg = require('./package.json') as Package;
+/** @type {PackageJson} */
+const pkg = require('./package.json');
 
-const outputPath = `dist`;
+const outputPath = 'dist';
 
 // Rollup writes bundle outputs; the TS plugin should only transpile.
 // - outputToFilesystem=false avoids outDir/dir validation errors for multi-output builds.
-// - incremental=false avoids TS build-info state referencing transient Rollup config artifacts.
+// - incremental=false avoids TS build-info state referencing transient Rollup artifacts.
 const typescript = typescriptPlugin({
   tsconfig: './tsconfig.json',
   outputToFilesystem: false,
-  // Only compile bundled sources; prevents transient Rollup config artifacts
-  // (e.g. rollup.config-*.mjs) from being pulled into the TS program.
   include: ['src/**/*.ts'],
   exclude: ['**/*.test.ts', '**/*.test.tsx', '**/__tests__/**'],
-
-  // Override repo tsconfig settings for bundling.
   noEmit: false,
   declaration: false,
   declarationMap: false,
@@ -46,29 +62,30 @@ const commonPlugins = [
   }),
 ];
 
-const commonAliases: Alias[] = [];
+/** @type {import('@rollup/plugin-alias').Alias[]} */
+const commonAliases = [];
+
+const dependencyExternals = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
 
 /**
  * Common input options for library builds (ESM only).
- * Externalize runtime dependencies and peers.
+ * Externalize runtime dependencies and node builtins.
  */
-const commonInputOptions: InputOptions = {
+const commonInputOptions = {
   input: 'src/index.ts',
-  external: [
-    ...Object.keys((pkg as unknown as Package).dependencies ?? {}),
-    ...Object.keys((pkg as unknown as Package).peerDependencies ?? {}),
-    'tslib',
-  ],
+  external: [...dependencyExternals, 'tslib', /^node:/],
   plugins: [aliasPlugin({ entries: commonAliases }), ...commonPlugins],
 };
 
 /** Discover CLI commands under src/cli. */
-const cliCommands = (await fs.readdir('src/cli').catch(() => [])) as string[];
+const cliCommands = await fs.readdir('src/cli').catch(() => []);
 
-/**
- * Build the library (ESM only).
- */
-export const buildLibrary = (dest: string): RollupOptions => ({
+/** Build the library (ESM only). */
+/** @param {string} dest */
+export const buildLibrary = (dest) => ({
   ...commonInputOptions,
   output: [
     {
@@ -79,25 +96,20 @@ export const buildLibrary = (dest: string): RollupOptions => ({
   ],
 });
 
-/**
- * Build bundled .d.ts at dest/index.d.ts.
- */
-export const buildTypes = (dest: string): RollupOptions => ({
+/** Build bundled .d.ts at dest/index.d.ts. */
+/** @param {string} dest */
+export const buildTypes = (dest) => ({
   input: 'src/index.ts',
+  external: [...dependencyExternals, /^node:/],
   output: [{ file: `${dest}/index.d.ts`, format: 'esm' }],
   plugins: [dtsPlugin()],
 });
 
 /** Assemble complete config (ESM library, types, and CLI outputs). */
-const config: RollupOptions[] = [
-  // Library output (ESM only)
+const config = [
   buildLibrary(outputPath),
-
-  // Type definitions output (single .d.ts)
   buildTypes(outputPath),
-
-  // CLI output.
-  ...cliCommands.map<RollupOptions>((c) => ({
+  ...cliCommands.map((c) => ({
     ...commonInputOptions,
     input: `src/cli/${c}/index.ts`,
     output: [

--- a/packages/service/src/api/routes.test.ts
+++ b/packages/service/src/api/routes.test.ts
@@ -6,6 +6,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Scheduler } from '../scheduler/scheduler.js';
+import { runnerConfigSchema } from '../schemas/config.js';
 import type { TestDb } from '../test-utils/db.js';
 import { createTestDb } from '../test-utils/db.js';
 import { registerRoutes } from './routes.js';
@@ -46,7 +47,12 @@ describe('API routes', () => {
     };
 
     app = Fastify({ logger: false });
-    registerRoutes(app, { db: testDb.db, scheduler: mockScheduler });
+    const defaultConfig = runnerConfigSchema.parse({});
+    registerRoutes(app, {
+      db: testDb.db,
+      scheduler: mockScheduler,
+      getConfig: () => defaultConfig,
+    });
     await app.ready();
   });
 
@@ -234,5 +240,31 @@ describe('API routes', () => {
     });
 
     expect(response.statusCode).toBe(404);
+  });
+
+  it('GET /config should return full config', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/config',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as { port: number };
+    expect(body.port).toBe(1937);
+  });
+
+  it('GET /config?path=$.port should return query result envelope', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/config?path=$.port',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      result: unknown[];
+      count: number;
+    };
+    expect(body.count).toBe(1);
+    expect(body.result).toEqual([1937]);
   });
 });

--- a/packages/service/src/api/routes.ts
+++ b/packages/service/src/api/routes.ts
@@ -1,24 +1,30 @@
 /**
- * Fastify API routes for job management and monitoring. Provides endpoints for job CRUD, run history, manual triggers, and system stats.
+ * Fastify API routes for job management and monitoring. Provides endpoints for job CRUD, run history, manual triggers, system stats, and config queries.
+ *
+ * @module routes
  */
 
 import type { DatabaseSync } from 'node:sqlite';
 
+import { createConfigQueryHandler } from '@karmaniverous/jeeves';
 import type { FastifyInstance } from 'fastify';
 
 import type { Scheduler } from '../scheduler/scheduler.js';
+import type { RunnerConfig } from '../schemas/config.js';
 
 /** Route dependencies. */
 interface RouteDeps {
   db: DatabaseSync;
   scheduler: Scheduler;
+  /** Getter for the current effective configuration. */
+  getConfig: () => RunnerConfig;
 }
 
 /**
  * Register all API routes on the Fastify instance.
  */
 export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
-  const { db, scheduler } = deps;
+  const { db, scheduler, getConfig } = deps;
 
   /** GET /health — Health check. */
   app.get('/health', () => {
@@ -139,4 +145,16 @@ export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
       errorsLastHour: errorsLastHour.count,
     };
   });
+
+  /** GET /config — Query effective configuration via JSONPath. */
+  const configHandler = createConfigQueryHandler(getConfig);
+  app.get<{ Querystring: { path?: string } }>(
+    '/config',
+    async (request, reply) => {
+      const result = await configHandler({
+        path: request.query.path,
+      });
+      return reply.status(result.status).send(result.body);
+    },
+  );
 }

--- a/packages/service/src/api/server.ts
+++ b/packages/service/src/api/server.ts
@@ -7,12 +7,15 @@ import type { DatabaseSync } from 'node:sqlite';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { Scheduler } from '../scheduler/scheduler.js';
+import type { RunnerConfig } from '../schemas/config.js';
 import { registerRoutes } from './routes.js';
 
 /** Server dependencies. */
 interface ServerDeps {
   db: DatabaseSync;
   scheduler: Scheduler;
+  /** Getter for the current effective configuration. */
+  getConfig: () => RunnerConfig;
   /** Pino logger config or false to disable. */
   loggerConfig?: { level: string; file?: string };
 }
@@ -37,7 +40,11 @@ export function createServer(deps: ServerDeps): FastifyInstance {
       : false,
   });
 
-  registerRoutes(app, deps);
+  registerRoutes(app, {
+    db: deps.db,
+    scheduler: deps.scheduler,
+    getConfig: deps.getConfig,
+  });
 
   return app;
 }

--- a/packages/service/src/cli/jeeves-runner/index.test.ts
+++ b/packages/service/src/cli/jeeves-runner/index.test.ts
@@ -11,6 +11,7 @@ import type { TestDb } from '../../test-utils/db.js';
 import { createTestDb } from '../../test-utils/db.js';
 
 describe('CLI', () => {
+  vi.setConfig({ testTimeout: 15000 });
   let testDb: TestDb;
   let configPath: string;
 

--- a/packages/service/src/runner.test.ts
+++ b/packages/service/src/runner.test.ts
@@ -75,5 +75,5 @@ describe('Runner', () => {
 
     // Verify server is stopped (connection should be refused)
     await expect(fetch('http://127.0.0.1:18783/health')).rejects.toThrow();
-  });
+  }, 20000);
 });

--- a/packages/service/src/runner.ts
+++ b/packages/service/src/runner.ts
@@ -114,6 +114,7 @@ export function createRunner(config: RunnerConfig, deps?: RunnerDeps): Runner {
       server = createServer({
         db,
         scheduler,
+        getConfig: () => config,
         loggerConfig: { level: config.log.level, file: config.log.file },
       });
       await server.listen({ port: config.port, host: '127.0.0.1' });

--- a/packages/service/src/scheduler/executor.test.ts
+++ b/packages/service/src/scheduler/executor.test.ts
@@ -135,7 +135,7 @@ describe('executeJob', () => {
     expect(result.status).toBe('ok');
     expect(result.exitCode).toBe(0);
     expect(result.stdoutTail).toContain('ps1-output');
-  });
+  }, 20000);
 
   it('should timeout long-running scripts', async () => {
     const script = join(testDir, 'slow.js');


### PR DESCRIPTION
Bump `@karmaniverous/jeeves` to `^0.2.0` and replace bespoke helpers with core SDK imports.

## Plugin (`packages/openclaw`)

- Delete local `PluginApi`, `ToolResult`, `ok()`, `fail()`, `connectionFail()`, `fetchJson()`, `postJson()` from `helpers.ts` — import from core
- Extract `PLUGIN_ID` to new `constants.ts`; `helpers.ts` retains `getApiUrl()` and `getConfigRoot()` wrappers using `resolvePluginSetting`  
- Replace `getPluginConfig()` / `getApiUrl()` with three-tier `resolvePluginSetting`  
- CLI: replace local `resolveOpenClawHome()` / `resolveConfigPath()` / `patchConfig()` with core imports
- Plugin uninstall: use `removeManagedSection()` from core for TOOLS.md cleanup
- DRY: extract repeated `encodeURIComponent(String(params.jobId))` into `jobPath()` helper
- Update rollup CLI config to bundle core SDK dependency (add `resolve()` + `commonjs()`)

## Service (`packages/service`)

- Add `@karmaniverous/jeeves` `^0.2.0` as runtime dependency
- Add `GET /config` endpoint via `createConfigQueryHandler()` (closes #27)
- Convert `rollup.config.ts` to `rollup.config.mjs` with JSDoc types

## Quality

- STAN 7/7 green (typecheck, lint, test, diagrams, docs, build, knip)
- 105 tests passing (20 plugin + 85 service)