### PR TITLE
chore: update core dependency to v0.3.0 and migrate /health to /status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,13 +1568,12 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.2.0.tgz",
-      "integrity": "sha512-o3wM1h04ayoaXs6hB1dYklqsEm/stM43e67zdEosUqkAiFwCLuOPwodB2bDaklZpYGxb9hcpPnF6rRyaMFwpPA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.3.0.tgz",
+      "integrity": "sha512-yb9BxKi+AOUdEsOOGqupyLzS9fbiQU1Pmzk5Cv/mFLpZoOui3xB6v3G4KBSbuWCuCHh5VKR6pviuzflFSGqX3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.2",
-        "handlebars": "^4.7.8",
         "jsonpath-plus": "^10.4.0",
         "package-directory": "^8.2.0",
         "proper-lockfile": "^4.1.2",
@@ -5257,6 +5256,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -6448,6 +6448,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6507,7 +6508,8 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -7915,6 +7917,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8297,6 +8300,7 @@
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -8606,7 +8610,8 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -8740,14 +8745,14 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-runner-openclaw",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-runner-openclaw": "dist/cli.js"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.52.0",
-        "@karmaniverous/jeeves": "^0.2.0",
+        "@karmaniverous/jeeves": "^0.3.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -8767,10 +8772,10 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-runner",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.2.0",
+        "@karmaniverous/jeeves": "^0.3.0",
         "@karmaniverous/rrstack": "^0.17.0",
         "commander": "^14.0.3",
         "croner": "^10.0.1",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.52.0",
-    "@karmaniverous/jeeves": "^0.2.0",
+    "@karmaniverous/jeeves": "^0.3.0",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/openclaw/src/generateContent.test.ts
+++ b/packages/openclaw/src/generateContent.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { generateRunnerContent } from './generateContent.js';
 
-/** Default stats fixture. */
-const defaultStats = {
+/** Default status fixture. */
+const defaultStatus = {
+  status: 'ok',
+  version: '0.6.0',
+  uptime: 3600,
   totalJobs: 2,
   running: 1,
   failedRegistrations: 0,
@@ -15,137 +18,54 @@ const defaultStats = {
   errorsLastHour: 1,
 };
 
-/** Mock fetch to return stats and jobs payloads. */
-function mockApi(
-  stats: Record<string, unknown>,
-  jobs: Record<string, unknown>[],
-): void {
-  vi.spyOn(globalThis, 'fetch').mockImplementation((url: unknown) => {
-    const u = String(url);
-    if (u.endsWith('/stats')) {
-      return Promise.resolve(
-        new Response(JSON.stringify(stats), { status: 200 }),
-      );
-    }
-    if (u.endsWith('/jobs')) {
-      return Promise.resolve(
-        new Response(JSON.stringify({ jobs }), { status: 200 }),
-      );
-    }
-    return Promise.resolve(new Response('not found', { status: 404 }));
-  });
+/** Mock fetch to return a status payload. */
+function mockStatus(status: Record<string, unknown>): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response(JSON.stringify(status), { status: 200 }),
+  );
 }
 
 describe('generateRunnerContent', () => {
-  it('renders stats + jobs', async () => {
-    const jobs = [
-      {
-        id: 'a',
-        name: 'Job A',
-        enabled: true,
-        schedule: '* * * * *',
-        lastRun: { status: 'ok', finished_at: '2026-01-01T00:00:00.000Z' },
-      },
-      {
-        id: 'b',
-        name: 'Job B',
-        enabled: false,
-        schedule: '0 * * * *',
-      },
-    ];
-
-    mockApi(defaultStats, jobs);
+  it('renders stats summary from /status', async () => {
+    mockStatus(defaultStatus);
 
     const md = await generateRunnerContent('http://localhost:1937');
 
-    expect(md).toContain('jeeves-runner connected on http://localhost:1937');
+    expect(md).toContain(
+      'jeeves-runner v0.6.0 connected on http://localhost:1937',
+    );
     expect(md).toContain('| Total jobs | 2 |');
-    expect(md).toContain('### Jobs');
-    expect(md).toContain('| Job A |');
-    expect(md).toContain('Job B *(disabled)*');
+    expect(md).toContain('| Running | 1 |');
+    expect(md).toContain('| OK last hour | 5 |');
+    expect(md).toContain('| Errors last hour | 1 |');
+  });
+
+  it('does not include a job listing table', async () => {
+    mockStatus(defaultStatus);
+
+    const md = await generateRunnerContent('http://localhost:1937');
+    expect(md).not.toContain('### Jobs');
   });
 
   it('includes failed registrations row when non-zero', async () => {
-    const stats = { ...defaultStats, failedRegistrations: 2 };
-    mockApi(stats, []);
+    mockStatus({ ...defaultStatus, failedRegistrations: 2 });
 
     const md = await generateRunnerContent('http://localhost:1937');
     expect(md).toContain('| Failed registrations | 2 |');
   });
 
+  it('excludes failed registrations row when zero', async () => {
+    mockStatus(defaultStatus);
+
+    const md = await generateRunnerContent('http://localhost:1937');
+    expect(md).not.toContain('Failed registrations');
+  });
+
   it('returns action-required block when unreachable', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'));
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('boom'));
 
     const md = await generateRunnerContent('http://localhost:1937');
     expect(md).toContain('ACTION REQUIRED');
     expect(md).toContain('unreachable');
-  });
-
-  it('shows rrstack label for JSON schedule', async () => {
-    const jobs = [
-      {
-        id: 'rr',
-        name: 'RRStack Job',
-        enabled: true,
-        schedule: '{"freq":"daily","interval":1}',
-      },
-    ];
-
-    mockApi(defaultStats, jobs);
-
-    const md = await generateRunnerContent('http://localhost:1937');
-    expect(md).toContain('*(rrstack)*');
-    expect(md).not.toContain('`{"freq"');
-  });
-
-  it('shows cron schedule in backticks', async () => {
-    const jobs = [
-      {
-        id: 'c',
-        name: 'Cron Job',
-        enabled: true,
-        schedule: '*/5 * * * *',
-      },
-    ];
-
-    mockApi(defaultStats, jobs);
-
-    const md = await generateRunnerContent('http://localhost:1937');
-    expect(md).toContain('`*/5 * * * *`');
-  });
-
-  it('tags inline source_type jobs', async () => {
-    const jobs = [
-      {
-        id: 'inl',
-        name: 'Inline Job',
-        enabled: true,
-        schedule: '* * * * *',
-        source_type: 'inline',
-      },
-    ];
-
-    mockApi(defaultStats, jobs);
-
-    const md = await generateRunnerContent('http://localhost:1937');
-    expect(md).toContain('*(inline)*');
-  });
-
-  it('does not tag path source_type jobs', async () => {
-    const jobs = [
-      {
-        id: 'p',
-        name: 'Path Job',
-        enabled: true,
-        schedule: '* * * * *',
-        source_type: 'path',
-      },
-    ];
-
-    mockApi(defaultStats, jobs);
-
-    const md = await generateRunnerContent('http://localhost:1937');
-    expect(md).not.toContain('*(inline)*');
-    expect(md).toContain('| Path Job |');
   });
 });

--- a/packages/openclaw/src/generateContent.ts
+++ b/packages/openclaw/src/generateContent.ts
@@ -6,51 +6,16 @@
 
 import { fetchJson } from '@karmaniverous/jeeves';
 
-/** Stats response from GET /stats. */
-interface RunnerStats {
+/** Status response from GET /status. */
+interface RunnerStatus {
+  status: string;
+  version: string;
+  uptime: number;
   totalJobs: number;
   running: number;
   failedRegistrations: number;
   okLastHour: number;
   errorsLastHour: number;
-}
-
-/** Job summary from GET /jobs. */
-interface JobSummary {
-  id: string;
-  name: string;
-  enabled: boolean;
-  schedule: string;
-  source_type?: string;
-  lastRun?: {
-    status: string;
-    finished_at?: string;
-  };
-}
-
-/** Detect whether a schedule string is rrstack JSON or cron. */
-function scheduleFormat(schedule: string): 'rrstack' | 'cron' {
-  try {
-    const parsed: unknown = JSON.parse(schedule);
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed)
-    ) {
-      return 'rrstack';
-    }
-  } catch {
-    // Not JSON — treat as cron
-  }
-  return 'cron';
-}
-
-/** Format a schedule for display: backtick-wrap cron, label rrstack. */
-function formatSchedule(schedule: string): string {
-  if (scheduleFormat(schedule) === 'rrstack') {
-    return '*(rrstack)*';
-  }
-  return `\`${schedule}\``;
 }
 
 /**
@@ -61,64 +26,26 @@ function formatSchedule(schedule: string): string {
  */
 export async function generateRunnerContent(baseUrl: string): Promise<string> {
   try {
-    const [statsRaw, jobsRaw] = await Promise.all([
-      fetchJson(`${baseUrl}/stats`),
-      fetchJson(`${baseUrl}/jobs`),
-    ]);
-
-    const stats = statsRaw as RunnerStats;
-
-    const jobs = (() => {
-      if (Array.isArray(jobsRaw)) return jobsRaw as JobSummary[];
-      if (jobsRaw && typeof jobsRaw === 'object' && 'jobs' in jobsRaw) {
-        const candidate = (jobsRaw as { jobs?: unknown }).jobs;
-        if (Array.isArray(candidate)) return candidate as JobSummary[];
-      }
-      return [];
-    })();
+    const data = (await fetchJson(`${baseUrl}/status`)) as RunnerStatus;
 
     const lines: string[] = [];
 
-    // Health summary
-    lines.push(`jeeves-runner connected on ${baseUrl}.`);
+    lines.push(`jeeves-runner v${data.version} connected on ${baseUrl}.`);
     lines.push('');
     lines.push(`| Metric | Value |`);
     lines.push(`|--------|-------|`);
-    lines.push(`| Total jobs | ${String(stats.totalJobs)} |`);
-    lines.push(`| Running | ${String(stats.running)} |`);
-    lines.push(`| OK last hour | ${String(stats.okLastHour)} |`);
-    lines.push(`| Errors last hour | ${String(stats.errorsLastHour)} |`);
+    lines.push(`| Total jobs | ${String(data.totalJobs)} |`);
+    lines.push(`| Running | ${String(data.running)} |`);
+    lines.push(`| OK last hour | ${String(data.okLastHour)} |`);
+    lines.push(`| Errors last hour | ${String(data.errorsLastHour)} |`);
 
-    if (stats.failedRegistrations > 0) {
+    if (data.failedRegistrations > 0) {
       lines.push(
-        `| Failed registrations | ${String(stats.failedRegistrations)} |`,
+        `| Failed registrations | ${String(data.failedRegistrations)} |`,
       );
     }
 
     lines.push('');
-
-    // Job table
-    if (Array.isArray(jobs) && jobs.length > 0) {
-      lines.push('### Jobs');
-      lines.push('');
-      lines.push('| Job | Schedule | Status | Last Run |');
-      lines.push('|-----|----------|--------|----------|');
-
-      for (const job of jobs) {
-        const enabled = job.enabled ? '' : ' *(disabled)*';
-        const status = job.lastRun?.status ?? '—';
-        const lastRun = job.lastRun?.finished_at
-          ? new Date(job.lastRun.finished_at).toISOString()
-          : '—';
-        const sched = formatSchedule(job.schedule);
-        const sourceTag = job.source_type === 'inline' ? ' *(inline)*' : '';
-        lines.push(
-          `| ${job.name}${enabled}${sourceTag} | ${sched} | ${status} | ${lastRun} |`,
-        );
-      }
-
-      lines.push('');
-    }
 
     return lines.join('\n');
   } catch {

--- a/packages/openclaw/src/runnerTools.test.ts
+++ b/packages/openclaw/src/runnerTools.test.ts
@@ -63,8 +63,11 @@ describe('registerRunnerTools', () => {
     }
   });
 
-  it('runner_status calls GET /stats', async () => {
+  it('runner_status calls GET /status', async () => {
     const mockResponse = {
+      status: 'ok',
+      version: '0.6.0',
+      uptime: 3600,
       totalJobs: 28,
       running: 0,
       failedRegistrations: 0,
@@ -82,7 +85,7 @@ describe('registerRunnerTools', () => {
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
     expect(fetch).toHaveBeenCalledWith(
-      'http://localhost:1937/stats',
+      'http://localhost:1937/status',
       undefined,
     );
   });

--- a/packages/openclaw/src/runnerTools.ts
+++ b/packages/openclaw/src/runnerTools.ts
@@ -25,7 +25,7 @@ export function registerRunnerTools(api: PluginApi, baseUrl: string): void {
       description:
         'Job counts (total, running), failed registrations, ok/error counts last hour',
       parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/stats'],
+      buildRequest: () => ['/status'],
     },
     {
       name: 'runner_jobs',

--- a/packages/openclaw/src/serviceCommands.test.ts
+++ b/packages/openclaw/src/serviceCommands.test.ts
@@ -10,11 +10,20 @@ import {
 } from './serviceCommands.js';
 
 describe('createRunnerServiceCommands', () => {
-  it('status returns running state from /health', async () => {
-    const health = { ok: true, uptime: 3600, version: '0.3.1' };
+  it('status returns running state from /status', async () => {
+    const statusResp = {
+      status: 'ok',
+      uptime: 3600,
+      version: '0.6.0',
+      totalJobs: 40,
+      running: 0,
+      failedRegistrations: 0,
+      okLastHour: 10,
+      errorsLastHour: 0,
+    };
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response(JSON.stringify(health), { status: 200 }),
+      new Response(JSON.stringify(statusResp), { status: 200 }),
     );
 
     const cmds = createRunnerServiceCommands('http://localhost:1937');
@@ -22,11 +31,11 @@ describe('createRunnerServiceCommands', () => {
 
     expect(status).toEqual({
       running: true,
-      version: '0.3.1',
+      version: '0.6.0',
       uptimeSeconds: 3600,
     });
     expect(fetch).toHaveBeenCalledWith(
-      'http://localhost:1937/health',
+      'http://localhost:1937/status',
       undefined,
     );
   });

--- a/packages/openclaw/src/serviceCommands.ts
+++ b/packages/openclaw/src/serviceCommands.ts
@@ -11,11 +11,11 @@ import {
   type ServiceStatus,
 } from '@karmaniverous/jeeves';
 
-/** Health response from GET /health. */
-interface HealthResponse {
-  ok: boolean;
+/** Status response from GET /status. */
+interface StatusResponse {
+  status: string;
+  version: string;
   uptime: number;
-  version?: string;
 }
 
 /**
@@ -44,11 +44,11 @@ export function createRunnerServiceCommands(baseUrl: string): ServiceCommands {
 
     async status(): Promise<ServiceStatus> {
       try {
-        const health = (await fetchJson(`${baseUrl}/health`)) as HealthResponse;
+        const data = (await fetchJson(`${baseUrl}/status`)) as StatusResponse;
         return {
-          running: health.ok,
-          version: health.version,
-          uptimeSeconds: health.uptime,
+          running: data.status === 'ok',
+          version: data.version,
+          uptimeSeconds: data.uptime,
         };
       } catch {
         return { running: false };

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -46,7 +46,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.2.0",
+    "@karmaniverous/jeeves": "^0.3.0",
     "@karmaniverous/rrstack": "^0.17.0",
     "commander": "^14.0.3",
     "croner": "^10.0.1",

--- a/packages/service/src/api/routes.test.ts
+++ b/packages/service/src/api/routes.test.ts
@@ -26,15 +26,31 @@ describe('API routes', () => {
     testDb.cleanup();
   });
 
-  it('GET /health should return ok', async () => {
+  it('GET /status should return status with version and stats', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: '/health',
+      url: '/status',
     });
 
     expect(response.statusCode).toBe(200);
-    const body = JSON.parse(response.body) as { ok: boolean };
-    expect(body.ok).toBe(true);
+    const body = JSON.parse(response.body) as {
+      status: string;
+      version: string;
+      uptime: number;
+      totalJobs: number;
+      running: number;
+      failedRegistrations: number;
+      okLastHour: number;
+      errorsLastHour: number;
+    };
+    expect(body.status).toBe('ok');
+    expect(body.version).toBe('0.0.0-test');
+    expect(body).toHaveProperty('uptime');
+    expect(body).toHaveProperty('totalJobs');
+    expect(body).toHaveProperty('running');
+    expect(body).toHaveProperty('failedRegistrations');
+    expect(body).toHaveProperty('okLastHour');
+    expect(body).toHaveProperty('errorsLastHour');
   });
 
   it('GET /jobs should return empty list', async () => {
@@ -125,23 +141,6 @@ describe('API routes', () => {
     });
 
     expect(response.statusCode).toBe(404);
-  });
-
-  it('GET /stats should return statistics', async () => {
-    const response = await app.inject({
-      method: 'GET',
-      url: '/stats',
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = JSON.parse(response.body) as {
-      totalJobs: number;
-      running: number;
-      failedRegistrations: number;
-    };
-    expect(body).toHaveProperty('totalJobs');
-    expect(body).toHaveProperty('running');
-    expect(body).toHaveProperty('failedRegistrations');
   });
 
   it('GET /config should return full config', async () => {

--- a/packages/service/src/api/routes.ts
+++ b/packages/service/src/api/routes.ts
@@ -21,20 +21,45 @@ interface RouteDeps {
   scheduler: Scheduler;
   /** Getter for the current effective configuration. */
   getConfig: () => RunnerConfig;
+  /** Service version string (from package.json). */
+  version: string;
 }
 
 /**
  * Register all API routes on the Fastify instance.
  */
 export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
-  const { db, scheduler, getConfig } = deps;
+  const { db, scheduler, getConfig, version } = deps;
 
-  /** GET /health — Health check. */
-  app.get('/health', () => {
+  /** GET /status — Unified status endpoint (single health/metadata entrypoint). */
+  app.get('/status', () => {
+    const totalJobs = db
+      .prepare('SELECT COUNT(*) as count FROM jobs')
+      .get() as { count: number };
+    const runningCount = scheduler.getRunningJobs().length;
+    const failedCount = scheduler.getFailedRegistrations().length;
+    const okLastHour = db
+      .prepare(
+        `SELECT COUNT(*) as count FROM runs 
+         WHERE status = 'ok' AND started_at > datetime('now', '-1 hour')`,
+      )
+      .get() as { count: number };
+    const errorsLastHour = db
+      .prepare(
+        `SELECT COUNT(*) as count FROM runs 
+         WHERE status IN ('error', 'timeout') AND started_at > datetime('now', '-1 hour')`,
+      )
+      .get() as { count: number };
+
     return {
-      ok: true,
+      status: 'ok',
+      version,
       uptime: process.uptime(),
-      failedRegistrations: scheduler.getFailedRegistrations().length,
+      totalJobs: totalJobs.count,
+      running: runningCount,
+      failedRegistrations: failedCount,
+      okLastHour: okLastHour.count,
+      errorsLastHour: errorsLastHour.count,
     };
   });
 
@@ -90,35 +115,6 @@ export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
       }
     },
   );
-
-  /** GET /stats — Aggregate job statistics. */
-  app.get('/stats', () => {
-    const totalJobs = db
-      .prepare('SELECT COUNT(*) as count FROM jobs')
-      .get() as { count: number };
-    const runningCount = scheduler.getRunningJobs().length;
-    const failedCount = scheduler.getFailedRegistrations().length;
-    const okLastHour = db
-      .prepare(
-        `SELECT COUNT(*) as count FROM runs 
-         WHERE status = 'ok' AND started_at > datetime('now', '-1 hour')`,
-      )
-      .get() as { count: number };
-    const errorsLastHour = db
-      .prepare(
-        `SELECT COUNT(*) as count FROM runs 
-         WHERE status IN ('error', 'timeout') AND started_at > datetime('now', '-1 hour')`,
-      )
-      .get() as { count: number };
-
-    return {
-      totalJobs: totalJobs.count,
-      running: runningCount,
-      failedRegistrations: failedCount,
-      okLastHour: okLastHour.count,
-      errorsLastHour: errorsLastHour.count,
-    };
-  });
 
   /** GET /config — Query effective configuration via JSONPath. */
   const configHandler = createConfigQueryHandler(getConfig);

--- a/packages/service/src/api/server.ts
+++ b/packages/service/src/api/server.ts
@@ -18,6 +18,8 @@ interface ServerDeps {
   scheduler: Scheduler;
   /** Getter for the current effective configuration. */
   getConfig: () => RunnerConfig;
+  /** Service version string (from package.json). */
+  version: string;
   /** Pino logger config or false to disable. */
   loggerConfig?: { level: string; file?: string };
 }
@@ -46,6 +48,7 @@ export function createServer(deps: ServerDeps): FastifyInstance {
     db: deps.db,
     scheduler: deps.scheduler,
     getConfig: deps.getConfig,
+    version: deps.version,
   });
 
   return app;

--- a/packages/service/src/cli/jeeves-runner/index.ts
+++ b/packages/service/src/cli/jeeves-runner/index.ts
@@ -76,7 +76,7 @@ program
     void (async () => {
       try {
         const resp = await fetch(
-          `http://127.0.0.1:${String(config.port)}/stats`,
+          `http://127.0.0.1:${String(config.port)}/status`,
         );
         const stats = (await resp.json()) as Record<string, unknown>;
         console.log(JSON.stringify(stats, null, 2));

--- a/packages/service/src/runner.test.ts
+++ b/packages/service/src/runner.test.ts
@@ -67,14 +67,15 @@ describe('Runner', () => {
     await runner.start();
 
     // Verify API server is listening
-    const response = await fetch('http://127.0.0.1:18783/health');
+    const response = await fetch('http://127.0.0.1:18783/status');
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { ok: boolean };
-    expect(body.ok).toBe(true);
+    const body = (await response.json()) as { status: string; version: string };
+    expect(body.status).toBe('ok');
+    expect(body.version).toBeDefined();
 
     await runner.stop();
 
     // Verify server is stopped (connection should be refused)
-    await expect(fetch('http://127.0.0.1:18783/health')).rejects.toThrow();
+    await expect(fetch('http://127.0.0.1:18783/status')).rejects.toThrow();
   }, 20000);
 });

--- a/packages/service/src/runner.ts
+++ b/packages/service/src/runner.ts
@@ -5,7 +5,9 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
 
 import type { FastifyInstance } from 'fastify';
 import type { Logger } from 'pino';
@@ -112,11 +114,25 @@ export function createRunner(config: RunnerConfig, deps?: RunnerDeps): Runner {
       scheduler.start();
       logger.info('Scheduler started');
 
+      // Read package version
+      const pkgVersion = (() => {
+        try {
+          const dir = dirname(fileURLToPath(import.meta.url));
+          const pkg = JSON.parse(
+            readFileSync(resolve(dir, '..', 'package.json'), 'utf8'),
+          ) as { version?: string };
+          return pkg.version ?? 'unknown';
+        } catch {
+          return 'unknown';
+        }
+      })();
+
       // API server
       server = createServer({
         db,
         scheduler,
         getConfig: () => config,
+        version: pkgVersion,
         loggerConfig: { level: config.log.level, file: config.log.file },
       });
       await server.listen({ port: config.port, host: config.host });

--- a/packages/service/src/test-utils/routes.ts
+++ b/packages/service/src/test-utils/routes.ts
@@ -62,6 +62,7 @@ export async function createRouteTestHarness(): Promise<RouteTestHarness> {
     db: testDb.db,
     scheduler,
     getConfig: () => defaultConfig,
+    version: '0.0.0-test',
   });
 
   await app.ready();


### PR DESCRIPTION
## Summary

Updates @karmaniverous/jeeves dependency to ^0.3.0 across the monorepo and addresses all breaking changes and associated issues.

Resolves #37 (Replace /health with root /status)
Resolves #36 (Remove full job listing from TOOLS.md managed section)

## What's New

### Service
- Replaced GET /health and GET /stats with a unified GET /status endpoint that conforms to the platform API standard.
- GET /status now returns { status: 'ok', version, uptime, totalJobs, running, failedRegistrations, okLastHour, errorsLastHour }.
- Service version is read dynamically from package.json at startup.
- All tests updated to target /status.

### Plugin
- Upgraded core dependency to ^0.3.0.
- Dropped unused imports (PluginApiLike, postJson, etc.) that were removed in the core update.
- Updated unner_status tool to target /status.
- Updated serviceCommands.status() to expect the new response shape.
- Trimmed generateContent.ts to output only summary stats into the TOOLS.md managed section (resolving #36), reducing context pollution.

## Quality Gates
- **STAN 7/7** green
- 152 tests passing
- Zero errors, zero warnings