### PR TITLE
fix(openclaw): do not send Content-Type on bodyless DELETE requests

### DIFF
--- a/packages/openclaw/src/runnerTools.test.ts
+++ b/packages/openclaw/src/runnerTools.test.ts
@@ -188,6 +188,11 @@ describe('registerRunnerTools', () => {
       'http://localhost:1937/jobs/old-job',
       expect.objectContaining({ method: 'DELETE' }),
     );
+
+    // DELETE with no body must not send Content-Type (Fastify rejects empty JSON body)
+    const callArgs = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(callArgs[1].headers).toBeUndefined();
+    expect(callArgs[1].body).toBeUndefined();
   });
 
   it('runner_query_state calls GET /state/:namespace', async () => {

--- a/packages/openclaw/src/toolHelpers.ts
+++ b/packages/openclaw/src/toolHelpers.ts
@@ -49,8 +49,12 @@ export function registerApiTool(
             method && method !== 'GET'
               ? {
                   method,
-                  headers: { 'Content-Type': 'application/json' },
-                  ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+                  ...(body !== undefined
+                    ? {
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(body),
+                      }
+                    : {}),
                 }
               : undefined;
 


### PR DESCRIPTION
Fixes runner_delete_job failing with Fastify 400 (empty JSON body).

toolHelpers.ts was unconditionally setting Content-Type: application/json for all non-GET methods, even when no body was present. Fastify rejects requests with Content-Type: application/json but an empty body.

Fix: only set Content-Type and body when body is defined. Added test assertion verifying DELETE sends no headers or body.