### PR TITLE
feat(service): add configurable tsRunner for TypeScript scripts

### DIFF
--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -28,7 +28,11 @@ export type {
   ExecutionResult,
   ResolvedCommand,
 } from './scheduler/executor.js';
-export { executeJob } from './scheduler/executor.js';
+export {
+  executeJob,
+  resolveCommand,
+  TS_EXTENSIONS,
+} from './scheduler/executor.js';
 
 // Scheduler
 export type { Scheduler, SchedulerDeps } from './scheduler/scheduler.js';

--- a/packages/service/src/runner.test.ts
+++ b/packages/service/src/runner.test.ts
@@ -26,6 +26,7 @@ function testConfig(dbPath: string, port: number) {
       defaultOnFailure: null,
     },
     gateway: { url: 'http://127.0.0.1:18789' },
+    tsRunner: 'tsx',
   };
 }
 

--- a/packages/service/src/scheduler/executor.test.ts
+++ b/packages/service/src/scheduler/executor.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const isWindows = process.platform === 'win32';
 
-import { executeJob } from './executor.js';
+import { executeJob, resolveCommand, TS_EXTENSIONS } from './executor.js';
 
 describe('executeJob', () => {
   let testDir: string;
@@ -158,6 +158,63 @@ describe('executeJob', () => {
     expect(result.status).toBe('timeout');
     expect(result.error).toContain('timed out');
   }, 10000);
+
+  describe('resolveCommand', () => {
+    it('should resolve .ts to tsRunner', () => {
+      const cmd = resolveCommand('/path/to/script.ts');
+      expect(cmd.command).toBe('tsx');
+      expect(cmd.args).toEqual(['/path/to/script.ts']);
+    });
+
+    it('should resolve .ts with custom tsRunner', () => {
+      const cmd = resolveCommand('/path/to/script.ts', '/custom/bin/tsx');
+      expect(cmd.command).toBe('/custom/bin/tsx');
+      expect(cmd.args).toEqual(['/path/to/script.ts']);
+    });
+
+    it('should resolve .mts to tsRunner', () => {
+      const cmd = resolveCommand('/path/to/script.mts');
+      expect(cmd.command).toBe('tsx');
+    });
+
+    it('should resolve .cts to tsRunner', () => {
+      const cmd = resolveCommand('/path/to/script.cts');
+      expect(cmd.command).toBe('tsx');
+    });
+
+    it('should resolve .tsx to tsRunner', () => {
+      const cmd = resolveCommand('/path/to/script.tsx');
+      expect(cmd.command).toBe('tsx');
+    });
+
+    it('should resolve .js to node', () => {
+      const cmd = resolveCommand('/path/to/script.js');
+      expect(cmd.command).toBe('node');
+    });
+
+    it('should cover all expected TS extensions', () => {
+      expect(TS_EXTENSIONS).toEqual(new Set(['.ts', '.tsx', '.mts', '.cts']));
+    });
+  });
+
+  it('should execute a .ts script via tsRunner', async () => {
+    const script = join(testDir, 'hello.ts');
+    // Write plain JS that's also valid TS (no type syntax needed)
+    writeFileSync(script, 'console.log("ts-output"); process.exit(0);');
+
+    const result = await executeJob({
+      script,
+      dbPath: ':memory:',
+      jobId: 'ts-test',
+      runId: 1,
+      // Use node with --experimental-strip-types as tsRunner since tsx may not be available
+      tsRunner: 'node',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdoutTail).toContain('ts-output');
+  });
 
   it('should execute an inline script', async () => {
     const result = await executeJob({

--- a/packages/service/src/scheduler/executor.ts
+++ b/packages/service/src/scheduler/executor.ts
@@ -53,6 +53,8 @@ export interface ExecutionOptions {
   commandResolver?: (script: string) => ResolvedCommand;
   /** Source type: 'path' uses script as file path, 'inline' writes script content to a temp file. */
   sourceType?: 'path' | 'inline';
+  /** Command used to execute TypeScript files. Defaults to 'tsx'. */
+  tsRunner?: string;
 }
 
 /** Ring buffer for capturing last N lines of output. */
@@ -100,8 +102,14 @@ function parseResultLines(stdout: string): {
   return { tokens, resultMeta };
 }
 
+/** TypeScript file extensions that should be executed via tsRunner. */
+export const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
 /** Resolve the command and arguments for a script based on its file extension. */
-function resolveCommand(script: string): ResolvedCommand {
+export function resolveCommand(
+  script: string,
+  tsRunner = 'tsx',
+): ResolvedCommand {
   const ext = extname(script).toLowerCase();
   switch (ext) {
     case '.ps1':
@@ -113,6 +121,9 @@ function resolveCommand(script: string): ResolvedCommand {
     case '.bat':
       return { command: 'cmd.exe', args: ['/c', script] };
     default:
+      if (TS_EXTENSIONS.has(ext)) {
+        return { command: tsRunner, args: [script] };
+      }
       // .js, .mjs, .cjs, or anything else: run with node
       return { command: 'node', args: [script] };
   }
@@ -132,6 +143,7 @@ export function executeJob(
     timeoutMs,
     commandResolver,
     sourceType = 'path',
+    tsRunner,
   } = options;
   const startTime = Date.now();
 
@@ -151,7 +163,7 @@ export function executeJob(
 
     const { command, args } = commandResolver
       ? commandResolver(effectiveScript)
-      : resolveCommand(effectiveScript);
+      : resolveCommand(effectiveScript, tsRunner);
     const child = spawn(command, args, {
       env: {
         ...process.env,

--- a/packages/service/src/scheduler/scheduler.ts
+++ b/packages/service/src/scheduler/scheduler.ts
@@ -122,6 +122,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
           runId,
           timeoutMs: timeout_ms ?? undefined,
           sourceType: source_type ?? 'path',
+          tsRunner: config.tsRunner,
         });
       }
 

--- a/packages/service/src/schemas/config.ts
+++ b/packages/service/src/schemas/config.ts
@@ -61,6 +61,8 @@ export const runnerConfigSchema = z.object({
   log: logSchema.default({ level: 'info' }),
   /** Gateway configuration for session-type jobs. */
   gateway: gatewaySchema.default({ url: 'http://127.0.0.1:18789' }),
+  /** Command used to execute .ts/.tsx/.mts/.cts scripts. Defaults to 'tsx'. Can be an absolute path. */
+  tsRunner: z.string().default('tsx'),
 });
 
 /** Inferred runner configuration type. */


### PR DESCRIPTION
Closes #45

## Summary

Add a configurable `tsRunner` field to the runner config (default: `tsx`) so the executor knows how to spawn `.ts` scripts directly.

## Changes

- **`schemas/config.ts`** — added `tsRunner` field (string, default `tsx`)
- **`scheduler/executor.ts`** — `resolveCommand()` now routes `.ts`/`.tsx`/`.mts`/`.cts` to the configured `tsRunner`; exported `resolveCommand` and `TS_EXTENSIONS` for testability
- **`scheduler/scheduler.ts`** — threads `config.tsRunner` into executor options
- **`index.ts`** — exports `resolveCommand` and `TS_EXTENSIONS`
- **`scheduler/executor.test.ts`** — 9 new tests: unit tests for `resolveCommand` with default/custom tsRunner across all TS extensions, plus integration test for `.ts` file execution
- **`runner.test.ts`** — added `tsRunner` to manual config fixture

## Verification

`stan run --sequential --no-archive` in `packages/service`: all 7 scripts green (typecheck, lint, test, diagrams, docs, build, knip).
