### PR TITLE
fix(service): correct startCommand path doubling in descriptor

### DIFF
--- a/packages/service/src/descriptor.ts
+++ b/packages/service/src/descriptor.ts
@@ -70,9 +70,11 @@ export function createRunnerDescriptor(
     initTemplate: () =>
       runnerConfigSchema.parse({}) as unknown as Record<string, unknown>,
     onConfigApply: options?.onConfigApply,
+    // MODULE_DIR resolves to the bundled CLI entry's directory at runtime
+    // (dist/cli/jeeves-runner/), so index.js is a sibling, not nested deeper.
     startCommand: (configPath: string) => [
       'node',
-      resolve(MODULE_DIR, 'cli', 'jeeves-runner', 'index.js'),
+      resolve(MODULE_DIR, 'index.js'),
       'start',
       '--config',
       configPath,


### PR DESCRIPTION
v0.8.0 crashes on startup because startCommand doubles the CLI path. Fix resolves index.js as a sibling.