### PR TITLE
chore(core): integrate 0.4.6 init fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,31 +190,6 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
@@ -222,7 +197,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1428,9 +1402,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.5.tgz",
-      "integrity": "sha512-jkq4vcBnx6dkbYFcHcfaq362fYriyr9+IQTlImn2h54NzfODfXxBukwt5o70Wfu4vo5BhrlQp0H2zkCTRQtE0Q==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.6.tgz",
+      "integrity": "sha512-GVxk4zTO48H56x1OTU1ZKSQF/3KBygSIGhrjHIzCFdFK7RvcHvRwo7aP2XIiV1vR8k1h+1IiOozVruoB94CWmg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.3",
@@ -1541,6 +1515,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1641,6 +1616,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3127,6 +3103,7 @@
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -3166,6 +3143,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3561,6 +3539,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4377,6 +4356,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4453,6 +4433,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4509,6 +4490,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6027,6 +6009,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7629,6 +7612,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8075,6 +8059,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8713,6 +8698,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8759,6 +8745,7 @@
       "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -8803,6 +8790,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8926,6 +8914,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9004,6 +8993,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -9439,6 +9429,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9509,14 +9500,14 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-runner-openclaw",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-runner-openclaw": "dist/cli.js"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.59.1",
-        "@karmaniverous/jeeves": "^0.4.5",
+        "@karmaniverous/jeeves": "^0.4.6",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -9536,10 +9527,10 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-runner",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.4.5",
+        "@karmaniverous/jeeves": "^0.4.6",
         "@karmaniverous/rrstack": "^0.17.1",
         "commander": "^14.0.3",
         "croner": "^10.0.1",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.59.1",
-    "@karmaniverous/jeeves": "^0.4.5",
+    "@karmaniverous/jeeves": "^0.4.6",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -46,7 +46,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.4.5",
+    "@karmaniverous/jeeves": "^0.4.6",
     "@karmaniverous/rrstack": "^0.17.1",
     "commander": "^14.0.3",
     "croner": "^10.0.1",


### PR DESCRIPTION
## Summary
- bump core to @karmaniverous/jeeves ^0.4.6
- integrate the upstream init-before-run fix from jeeves PR #54
- refresh lockfile

## Verification
- npm run typecheck
- npm run build --workspaces
- stan run --sequential --no-archive
- npx npm-check-updates --peer (reviewed only; not applied)

## Notes
ncu shows two available updates at the root:
- typescript ^5.9.3 -> ^6.0.2 (major; not applied)
- typescript-eslint ^8.57.2 -> ^8.58.0 (minor; not applied in this PR)
