### PR TITLE
chore: move changelog generation to after:bump hook

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -93,17 +93,14 @@
     },
     "hooks": {
       "after:bump": [
-        "node -e \"const f='openclaw.plugin.json';const j=JSON.parse(require('fs').readFileSync(f,'utf8'));j.version='${version}';require('fs').writeFileSync(f,JSON.stringify(j,null,2)+'\\n')\""
+        "npx auto-changelog -p",
+        "git add CHANGELOG.md"
       ],
       "after:init": [
         "npm run lint",
         "npm run typecheck",
         "npm run test",
         "npm run build"
-      ],
-      "before:npm:release": [
-        "npx auto-changelog -p",
-        "git add -A"
       ],
       "after:release": [
         "git switch -c release/openclaw/${version}",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -112,14 +112,14 @@
         "npm run test",
         "npm run build"
       ],
-      "before:npm:release": [
-        "npx auto-changelog -p",
-        "git add -A"
-      ],
       "after:release": [
         "git switch -c release/service/${version}",
         "git push -u origin release/service/${version}",
         "git switch ${branchName}"
+      ],
+      "after:bump": [
+        "npx auto-changelog -p",
+        "git add CHANGELOG.md"
       ]
     },
     "npm": {


### PR DESCRIPTION
Move auto-changelog generation from before:npm:release to after:bump so the updated CHANGELOG.md is included in the release commit and tag. Also narrows git add -A to git add CHANGELOG.md to avoid staging unrelated files.