### PR TITLE
fix: resolve dispatcher issues and skill docs (#50, #64, #70, #78)

### DIFF
--- a/packages/openclaw/skills/jeeves-runner/SKILL.md
+++ b/packages/openclaw/skills/jeeves-runner/SKILL.md
@@ -509,6 +509,8 @@ Get-Content <log-path> -Tail 20   # Recent logs
 
 ## Script Authoring
 
+For script authoring patterns (repo setup, TypeScript execution, script structure, quality gates), see the [jeeves-scripts README](https://github.com/karmaniverous/jeeves-scripts/blob/main/README.md).
+
 ### Template Repo
 
 New script projects start from `karmaniverous/jeeves-scripts-template`. Use the CLI to scaffold:
@@ -587,7 +589,7 @@ Scripts should pass these quality gates before deployment:
 
 ### Job Registration
 
-Register jobs via the HTTP API or CLI:
+Register jobs via the `runner_create_job` tool or CLI. Required fields: `id`, `name`, `schedule`, `script`.
 
 ```bash
 # Via CLI
@@ -595,6 +597,26 @@ jeeves-runner add-job -i my-job -n "My Job" -s "*/5 * * * *" --script /path/to/s
 
 # Via API tool
 runner_create_job id="my-job" name="My Job" schedule="*/5 * * * *" script="/path/to/script.ts"
+```
+
+#### Dispatcher pattern (`type='script'`)
+
+For jobs that need both mechanical data prep and LLM reasoning. The script gathers data, builds context, then calls `dispatchSession()` to spawn an LLM session for the reasoning step:
+
+```bash
+runner_create_job id="daily-digest" name="Daily Digest" schedule="0 8 * * *" script="/path/to/digest.ts" type="script"
+```
+
+#### Direct session pattern (`type='session'`)
+
+For pure LLM tasks where the prompt is either raw text or a `.md`/`.txt` file. No script execution — the runner spawns a Gateway session directly:
+
+```bash
+# Prompt text inline
+runner_create_job id="morning-brief" name="Morning Brief" schedule="0 7 * * *" script="Summarize today's priorities from the queue." type="session"
+
+# Prompt from file
+runner_create_job id="weekly-review" name="Weekly Review" schedule="0 9 * * MON" script="/path/to/weekly-review.md" type="session"
 ```
 
 ## Engineering Standards for Process Scripts

--- a/packages/service/src/client/spawn-worker.test.ts
+++ b/packages/service/src/client/spawn-worker.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for spawn-worker dispatch functions.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dispatchSession } from './spawn-worker.js';
+
+describe('dispatchSession', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'jeeves-spawn-worker-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should resolve command via resolveCommand for .js worker', async () => {
+    const workerPath = join(testDir, 'worker.js');
+    writeFileSync(
+      workerPath,
+      'process.stdin.resume(); process.stdin.on("end", () => { console.log("ok"); process.exit(0); });',
+    );
+
+    const result = await dispatchSession(
+      'test task',
+      {
+        jobId: 'test-job',
+        timeout: 10,
+      },
+      workerPath,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('ok');
+  });
+
+  it('should use custom runner when specified', async () => {
+    const workerPath = join(testDir, 'worker.ts');
+    // Write plain JS that's also valid TS
+    writeFileSync(
+      workerPath,
+      'process.stdin.resume(); process.stdin.on("end", () => { console.log("ts-ok"); process.exit(0); });',
+    );
+
+    const result = await dispatchSession(
+      'test task',
+      {
+        jobId: 'test-job',
+        timeout: 10,
+        runners: { ts: 'node' },
+      },
+      workerPath,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('ts-ok');
+  });
+
+  it('should capture stdout from worker', async () => {
+    const workerPath = join(testDir, 'worker.js');
+    writeFileSync(
+      workerPath,
+      'process.stdin.resume(); process.stdin.on("end", () => { console.log("line1"); console.log("line2"); process.exit(0); });',
+    );
+
+    const result = await dispatchSession(
+      'test task',
+      {
+        jobId: 'test-job',
+        timeout: 10,
+      },
+      workerPath,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('line1');
+    expect(result.stdout).toContain('line2');
+  });
+
+  it('should pass flag args to worker', async () => {
+    const workerPath = join(testDir, 'worker.js');
+    writeFileSync(
+      workerPath,
+      'console.log(JSON.stringify(process.argv.slice(2))); process.exit(0);',
+    );
+
+    const result = await dispatchSession(
+      'test task',
+      {
+        jobId: 'my-job',
+        label: 'my-label',
+        thinking: 'high',
+        timeout: 60,
+      },
+      workerPath,
+    );
+
+    expect(result.exitCode).toBe(0);
+    const args = JSON.parse(result.stdout) as string[];
+    expect(args).toContain('--job-id=my-job');
+    expect(args).toContain('--label=my-label');
+    expect(args).toContain('--thinking=high');
+    expect(args).toContain('--timeout=60');
+  });
+});

--- a/packages/service/src/client/spawn-worker.ts
+++ b/packages/service/src/client/spawn-worker.ts
@@ -118,9 +118,10 @@ export function runDispatcher(
 
   dispatchSession(task, options, workerPath)
     .then(({ exitCode, stdout }) => {
-      if (options.outputChannel && stdout.trim()) {
+      const trimmedStdout = stdout.trim();
+      if (options.outputChannel && trimmedStdout) {
         console.log(
-          `JR_RESULT:${JSON.stringify({ output: stdout.trim(), outputChannel: options.outputChannel })}`,
+          `JR_RESULT:${JSON.stringify({ output: trimmedStdout, outputChannel: options.outputChannel })}`,
         );
       }
       process.exit(exitCode);

--- a/packages/service/src/client/spawn-worker.ts
+++ b/packages/service/src/client/spawn-worker.ts
@@ -7,6 +7,8 @@
 
 import { spawn } from 'node:child_process';
 
+import { resolveCommand } from '../scheduler/executor.js';
+
 /** Options for dispatching an LLM session. */
 export interface DispatchOptions {
   /** Job identifier. */
@@ -17,6 +19,18 @@ export interface DispatchOptions {
   thinking?: 'low' | 'medium' | 'high';
   /** Timeout in seconds (default 300). */
   timeout?: number;
+  /** Custom command runners keyed by file extension (e.g. `{ ts: "node /path/to/tsx/cli.mjs" }`). */
+  runners?: Record<string, string>;
+  /** Output channel identifier for routing session results. */
+  outputChannel?: string;
+}
+
+/** Result of a dispatched session. */
+export interface DispatchResult {
+  /** Exit code from the worker process. */
+  exitCode: number;
+  /** Captured stdout from the worker process. */
+  stdout: string;
 }
 
 /**
@@ -26,37 +40,49 @@ export interface DispatchOptions {
  * @param task - Prompt text for the LLM session.
  * @param options - Dispatch configuration.
  * @param workerPath - Path to the spawn-worker script.
- * @returns Exit code from the worker process.
+ * @returns Exit code and captured stdout from the worker process.
  */
 export function dispatchSession(
   task: string,
   options: DispatchOptions,
   workerPath: string,
-): Promise<number> {
+): Promise<DispatchResult> {
   return new Promise((resolve, reject) => {
-    const args = [
+    const { command, args: resolvedArgs } = resolveCommand(
       workerPath,
+      options.runners,
+    );
+
+    const flagArgs = [
       `--job-id=${options.jobId}`,
       `--timeout=${String(options.timeout ?? 300)}`,
     ];
 
     if (options.label) {
-      args.push(`--label=${options.label}`);
+      flagArgs.push(`--label=${options.label}`);
     }
 
     if (options.thinking) {
-      args.push(`--thinking=${options.thinking}`);
+      flagArgs.push(`--thinking=${options.thinking}`);
     }
 
-    const child = spawn('node', args, {
-      stdio: ['pipe', 'inherit', 'inherit'],
+    const child = spawn(command, [...resolvedArgs, ...flagArgs], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+
+    const chunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
     });
 
     child.stdin.write(task);
     child.stdin.end();
 
     child.on('close', (code) => {
-      resolve(code ?? 1);
+      resolve({
+        exitCode: code ?? 1,
+        stdout: Buffer.concat(chunks).toString(),
+      });
     });
 
     child.on('error', (err) => {
@@ -91,8 +117,13 @@ export function runDispatcher(
   }
 
   dispatchSession(task, options, workerPath)
-    .then((code) => {
-      process.exit(code);
+    .then(({ exitCode, stdout }) => {
+      if (options.outputChannel && stdout.trim()) {
+        console.log(
+          `JR_RESULT:${JSON.stringify({ output: stdout.trim(), outputChannel: options.outputChannel })}`,
+        );
+      }
+      process.exit(exitCode);
     })
     .catch((err: unknown) => {
       console.error(

--- a/packages/service/src/db/migrations.ts
+++ b/packages/service/src/db/migrations.ts
@@ -146,12 +146,18 @@ const MIGRATION_004 = `
 ALTER TABLE jobs ADD COLUMN source_type TEXT DEFAULT 'path';
 `;
 
+/** Migration 005: Add output_channel column to jobs. */
+const MIGRATION_005 = `
+ALTER TABLE jobs ADD COLUMN output_channel TEXT DEFAULT NULL;
+`;
+
 /** Registry of all migrations keyed by version number. */
 const MIGRATIONS: Record<number, string> = {
   1: MIGRATION_001,
   2: MIGRATION_002,
   3: MIGRATION_003,
   4: MIGRATION_004,
+  5: MIGRATION_005,
 };
 
 /**

--- a/packages/service/src/gateway/client.test.ts
+++ b/packages/service/src/gateway/client.test.ts
@@ -83,6 +83,13 @@ describe('Gateway client', () => {
                   totalTokens: 1500,
                   model: 'claude-3-sonnet',
                   transcriptPath: '/path/to/transcript.jsonl',
+                  status: 'done',
+                },
+                {
+                  sessionKey: 'active-session',
+                  totalTokens: 200,
+                  model: 'claude-3-sonnet',
+                  status: 'running',
                 },
                 {
                   sessionKey: 'other-session',
@@ -201,27 +208,36 @@ describe('Gateway client', () => {
     expect(info).toBeNull();
   });
 
-  it('should detect complete session', async () => {
+  it('should detect complete session via status', async () => {
     const client = createGatewayClient({
       url: `http://127.0.0.1:${String(port)}`,
       token: 'test-token',
     });
 
+    // test-session-123 has status: 'done'
     const isComplete = await client.isSessionComplete('test-session-123');
-
     expect(isComplete).toBe(true);
   });
 
-  it('should detect incomplete session (no stopReason)', async () => {
-    // Create a modified server response for this test
+  it('should detect incomplete session via status', async () => {
     const client = createGatewayClient({
       url: `http://127.0.0.1:${String(port)}`,
       token: 'test-token',
     });
 
-    // The mock returns a session with stopReason, so isComplete should be true
-    const isComplete = await client.isSessionComplete('test-session-123');
-    expect(isComplete).toBe(true);
+    // active-session has status: 'running'
+    const isComplete = await client.isSessionComplete('active-session');
+    expect(isComplete).toBe(false);
+  });
+
+  it('should capture status field in session info', async () => {
+    const client = createGatewayClient({
+      url: `http://127.0.0.1:${String(port)}`,
+      token: 'test-token',
+    });
+
+    const info = await client.getSessionInfo('test-session-123');
+    expect(info?.status).toBe('done');
   });
 
   it('should handle connection refused', async () => {

--- a/packages/service/src/gateway/client.ts
+++ b/packages/service/src/gateway/client.ts
@@ -53,6 +53,8 @@ export interface SessionInfo {
   model: string;
   /** Transcript file path (if available). */
   transcriptPath?: string;
+  /** Session status from sessions_list (e.g. 'done', 'error', 'timeout'). */
+  status?: string;
 }
 
 /** Gateway client for invoking tools via /tools/invoke. */
@@ -161,7 +163,9 @@ export function createGatewayClient(
         timeoutMs,
       )) as {
         ok: boolean;
-        result: Array<{ sessionKey: string } & SessionInfo>;
+        result: Array<
+          { sessionKey: string; status?: string } & Omit<SessionInfo, 'status'>
+        >;
       };
 
       if (!response.ok) {
@@ -175,10 +179,26 @@ export function createGatewayClient(
         totalTokens: session.totalTokens,
         model: session.model,
         transcriptPath: session.transcriptPath,
+        status: session.status,
       };
     },
 
     async isSessionComplete(sessionKey: string): Promise<boolean> {
+      // Primary: check session status via sessions_list
+      const info = await this.getSessionInfo(sessionKey);
+      if (info) {
+        if (
+          info.status === 'done' ||
+          info.status === 'error' ||
+          info.status === 'timeout'
+        ) {
+          return true;
+        }
+        // Session found and still active
+        return false;
+      }
+
+      // Fallback: session not found in sessions_list (may have aged out)
       const history = await this.getSessionHistory(sessionKey, 3);
       if (history.length === 0) return false;
 

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -79,5 +79,5 @@ export { migrateConfig } from './lib/migrate-config.js';
 
 // Client utilities (runner-specific; general utilities moved to @karmaniverous/jeeves)
 export { getRunnerClient } from './client/runner-client.js';
-export type { DispatchOptions } from './client/spawn-worker.js';
+export type { DispatchOptions, DispatchResult } from './client/spawn-worker.js';
 export { dispatchSession, runDispatcher } from './client/spawn-worker.js';

--- a/packages/service/src/schemas/job.test.ts
+++ b/packages/service/src/schemas/job.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for job schema.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { jobSchema } from './job.js';
+
+describe('jobSchema', () => {
+  it('should accept outputChannel as string', () => {
+    const result = jobSchema.parse({
+      id: 'test-job',
+      name: 'Test Job',
+      schedule: '*/5 * * * *',
+      script: '/path/to/script.js',
+      outputChannel: 'C0123456789',
+    });
+
+    expect(result.outputChannel).toBe('C0123456789');
+  });
+
+  it('should default outputChannel to null', () => {
+    const result = jobSchema.parse({
+      id: 'test-job',
+      name: 'Test Job',
+      schedule: '*/5 * * * *',
+      script: '/path/to/script.js',
+    });
+
+    expect(result.outputChannel).toBeNull();
+  });
+
+  it('should accept null outputChannel', () => {
+    const result = jobSchema.parse({
+      id: 'test-job',
+      name: 'Test Job',
+      schedule: '*/5 * * * *',
+      script: '/path/to/script.js',
+      outputChannel: null,
+    });
+
+    expect(result.outputChannel).toBeNull();
+  });
+});

--- a/packages/service/src/schemas/job.ts
+++ b/packages/service/src/schemas/job.ts
@@ -30,6 +30,8 @@ export const jobSchema = z.object({
   onFailure: z.string().nullable().default(null),
   /** Slack channel ID for success notifications. */
   onSuccess: z.string().nullable().default(null),
+  /** Output channel identifier for routing session results. */
+  outputChannel: z.string().nullable().default(null),
 });
 
 /** Inferred Job type from schema. */


### PR DESCRIPTION
## Summary
- **#78**: Replace hardcoded `spawn('node', ...)` in `dispatchSession` with `resolveCommand()` to honor custom `runners` config for worker scripts
- **#70**: Fix session completion polling to check session `status` from `sessions_list` (done/error/timeout) instead of fragile `stopReason` parsing, with history-based fallback for aged-out sessions
- **#64**: Add `outputChannel` field to job schema + DB migration 005, change `dispatchSession` to capture stdout (returns `DispatchResult` instead of raw exit code), emit `JR_RESULT` with output+channel in `runDispatcher`
- **#50**: Add canonical jeeves-scripts README reference and expanded job registration docs (dispatcher vs direct session patterns) to SKILL.md

Closes #50, closes #64, closes #70, closes #78

## Test plan
- [x] All 160 existing tests pass
- [x] New spawn-worker tests: resolveCommand usage, custom runners, stdout capture, flag args
- [x] New client test: status-based completion detection, incomplete session detection, status field capture
- [x] New job schema test: outputChannel string/null/default validation
- [x] Typecheck, lint, build pass for both packages
- [x] STAN passes all gates (typecheck, lint, test, diagrams, docs, build, knip)

## ncu --peer report
**Root**: `eslint-plugin-simple-import-sort` 12→13 (MAJOR), `typescript` 5→6 (MAJOR) — skipped. All others patch/minor.
**Service**: `@dotenvx/dotenvx`, `@types/node`, `rollup` — all patch/minor.
**OpenClaw**: `@dotenvx/dotenvx`, `knip`, `rollup` — all patch/minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)