### PR TITLE
fix: pin jeeves-runner-core dependency to ^0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9277,7 +9277,7 @@
     },
     "packages/core": {
       "name": "@karmaniverous/jeeves-runner-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
@@ -9514,7 +9514,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-runner-openclaw",
-      "version": "0.7.8",
+      "version": "0.7.10",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-runner-openclaw": "dist/cli.js"
@@ -9753,11 +9753,11 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-runner",
-      "version": "0.9.8",
+      "version": "0.9.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-runner-core": "*",
+        "@karmaniverous/jeeves-runner-core": "^0.1.1",
         "@karmaniverous/rrstack": "^0.17.1",
         "commander": "^14.0.3",
         "croner": "^10.0.1",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-runner-core": "*",
+    "@karmaniverous/jeeves-runner-core": "^0.1.1",
     "@karmaniverous/rrstack": "^0.17.1",
     "commander": "^14.0.3",
     "croner": "^10.0.1",


### PR DESCRIPTION
Pins the \@karmaniverous/jeeves-runner-core\ dependency in the service package from \*\ to \^0.1.1\ to ensure consistent resolution across installs.