### PR TITLE
feat: config harmonization (gatewayUrl, gatewayApiKey, logging) #81

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -83,6 +83,48 @@ describe('runnerConfigSchema', () => {
     });
 
     expect(config.logging.level).toBe('error');
+    // Should still warn and remove the deprecated key
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"log" is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns specifically about gateway.tokenPath removal', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = runnerConfigSchema.parse({
+      gateway: {
+        url: 'http://old-gateway:8080',
+        tokenPath: '/path/to/token',
+      },
+    });
+
+    expect(config.gatewayUrl).toBe('http://old-gateway:8080');
+    expect(config.gatewayApiKey).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"gateway.tokenPath"'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"gateway" is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('removes deprecated log key even when logging is present', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Simulate the preprocess output — log should be stripped
+    const config = runnerConfigSchema.parse({
+      logging: { level: 'error' },
+      log: { level: 'debug' },
+    });
+
+    // The parsed config should not have a 'log' key
+    expect(config).not.toHaveProperty('log');
+    expect(config.logging.level).toBe('error');
 
     warnSpy.mockRestore();
   });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -57,6 +57,23 @@ describe('runnerConfigSchema', () => {
     warnSpy.mockRestore();
   });
 
+  it('migrates full old config shape (gateway + log) in one pass', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = runnerConfigSchema.parse({
+      gateway: { url: 'http://old-gateway:8080' },
+      log: { level: 'warn', file: '/tmp/old.log' },
+    });
+
+    expect(config.gatewayUrl).toBe('http://old-gateway:8080');
+    expect(config.gatewayApiKey).toBeUndefined();
+    expect(config.logging.level).toBe('warn');
+    expect(config.logging.file).toBe('/tmp/old.log');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
   it('prefers new keys when both old and new are present', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runnerConfigSchema } from './config.js';
+
+describe('runnerConfigSchema', () => {
+  it('parses new config shape', () => {
+    const config = runnerConfigSchema.parse({
+      gatewayUrl: 'http://example.com:9999',
+      gatewayApiKey: 'my-secret',
+      logging: { level: 'debug', file: '/tmp/runner.log' },
+    });
+
+    expect(config.gatewayUrl).toBe('http://example.com:9999');
+    expect(config.gatewayApiKey).toBe('my-secret');
+    expect(config.logging.level).toBe('debug');
+    expect(config.logging.file).toBe('/tmp/runner.log');
+  });
+
+  it('applies defaults for empty input', () => {
+    const config = runnerConfigSchema.parse({});
+
+    expect(config.gatewayUrl).toBe('http://127.0.0.1:18789');
+    expect(config.gatewayApiKey).toBeUndefined();
+    expect(config.logging.level).toBe('info');
+    expect(config.logging.file).toBeUndefined();
+  });
+
+  it('migrates deprecated gateway object to flat keys', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = runnerConfigSchema.parse({
+      gateway: { url: 'http://old-gateway:8080' },
+    });
+
+    expect(config.gatewayUrl).toBe('http://old-gateway:8080');
+    expect(config.gatewayApiKey).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"gateway" is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('migrates deprecated log key to logging', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = runnerConfigSchema.parse({
+      log: { level: 'debug', file: '/tmp/old.log' },
+    });
+
+    expect(config.logging.level).toBe('debug');
+    expect(config.logging.file).toBe('/tmp/old.log');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"log" is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('prefers new keys when both old and new are present', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = runnerConfigSchema.parse({
+      logging: { level: 'error' },
+      log: { level: 'debug' },
+    });
+
+    expect(config.logging.level).toBe('error');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,8 +14,8 @@ const notificationsSchema = z.object({
   defaultOnSuccess: z.string().nullable().default(null),
 });
 
-/** Log configuration sub-schema. */
-const logSchema = z.object({
+/** Logging configuration sub-schema. */
+const loggingSchema = z.object({
   /** Log level threshold (trace, debug, info, warn, error, fatal). */
   level: z
     .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
@@ -24,44 +24,77 @@ const logSchema = z.object({
   file: z.string().optional(),
 });
 
-/** Gateway configuration sub-schema. */
-const gatewaySchema = z.object({
-  /** OpenClaw Gateway URL. */
-  url: z.string().default(DEFAULT_GATEWAY_URL),
-  /** Path to file containing Gateway auth token. */
-  tokenPath: z.string().optional(),
-});
+/**
+ * Migrate deprecated config keys to the new shape.
+ *
+ * - `gateway.url` → `gatewayUrl`
+ * - `gateway.tokenPath` → dropped (was file-based; use `gatewayApiKey` direct value)
+ * - `log` → `logging`
+ */
+function migrateDeprecatedKeys(input: unknown): unknown {
+  if (typeof input !== 'object' || input === null) return input;
+
+  const obj = { ...(input as Record<string, unknown>) };
+
+  // gateway → gatewayUrl
+  if ('gateway' in obj && typeof obj.gateway === 'object' && obj.gateway) {
+    const gw = obj.gateway as Record<string, unknown>;
+    if (!('gatewayUrl' in obj) && 'url' in gw) {
+      obj.gatewayUrl = gw.url;
+    }
+    delete obj.gateway;
+    console.warn(
+      '[jeeves-runner] DEPRECATED: config key "gateway" is deprecated. Use "gatewayUrl" and "gatewayApiKey" instead.',
+    );
+  }
+
+  // log → logging
+  if ('log' in obj && !('logging' in obj)) {
+    obj.logging = obj.log;
+    delete obj.log;
+    console.warn(
+      '[jeeves-runner] DEPRECATED: config key "log" is deprecated. Use "logging" instead.',
+    );
+  }
+
+  return obj;
+}
 
 /** Full runner configuration schema. Validates and provides defaults. */
-export const runnerConfigSchema = z.object({
-  /** HTTP server port for the runner API. */
-  port: z.number().default(RUNNER_PORT),
-  /** Bind address for the HTTP server. Defaults to the platform-standard bind address. */
-  host: z.string().default(DEFAULT_BIND_ADDRESS),
-  /** Path to SQLite database file. */
-  dbPath: z.string().default('./data/runner.sqlite'),
-  /** Maximum number of concurrent job executions. */
-  maxConcurrency: z.number().default(4),
-  /** Number of days to retain completed run records. */
-  runRetentionDays: z.number().default(30),
-  /** Interval in milliseconds for expired state cleanup task. */
-  stateCleanupIntervalMs: z.number().default(3600000),
-  /** Grace period in milliseconds for shutdown completion. */
-  shutdownGraceMs: z.number().default(30000),
-  /** Interval in milliseconds for job reconciliation checks. */
-  reconcileIntervalMs: z.number().default(60000),
-  /** Notification configuration for job completion events. */
-  notifications: notificationsSchema.default({
-    defaultOnFailure: null,
-    defaultOnSuccess: null,
+export const runnerConfigSchema = z.preprocess(
+  migrateDeprecatedKeys,
+  z.object({
+    /** HTTP server port for the runner API. */
+    port: z.number().default(RUNNER_PORT),
+    /** Bind address for the HTTP server. Defaults to the platform-standard bind address. */
+    host: z.string().default(DEFAULT_BIND_ADDRESS),
+    /** Path to SQLite database file. */
+    dbPath: z.string().default('./data/runner.sqlite'),
+    /** Maximum number of concurrent job executions. */
+    maxConcurrency: z.number().default(4),
+    /** Number of days to retain completed run records. */
+    runRetentionDays: z.number().default(30),
+    /** Interval in milliseconds for expired state cleanup task. */
+    stateCleanupIntervalMs: z.number().default(3600000),
+    /** Grace period in milliseconds for shutdown completion. */
+    shutdownGraceMs: z.number().default(30000),
+    /** Interval in milliseconds for job reconciliation checks. */
+    reconcileIntervalMs: z.number().default(60000),
+    /** Notification configuration for job completion events. */
+    notifications: notificationsSchema.default({
+      defaultOnFailure: null,
+      defaultOnSuccess: null,
+    }),
+    /** Logging configuration. */
+    logging: loggingSchema.default({ level: 'info' }),
+    /** OpenClaw Gateway URL. */
+    gatewayUrl: z.string().default(DEFAULT_GATEWAY_URL),
+    /** OpenClaw Gateway API key (direct value). Falls back to OPENCLAW_GATEWAY_TOKEN env var at runtime. */
+    gatewayApiKey: z.string().optional(),
+    /** Custom command runners keyed by file extension. The command string is split on whitespace; first token is the executable, rest are prefix args before the script path. Falls back to built-in defaults for unconfigured extensions. */
+    runners: z.record(z.string(), z.string().trim().min(1)).default({}),
   }),
-  /** Logging configuration. */
-  log: logSchema.default({ level: 'info' }),
-  /** Gateway configuration for session-type jobs. */
-  gateway: gatewaySchema.default({ url: DEFAULT_GATEWAY_URL }),
-  /** Custom command runners keyed by file extension. The command string is split on whitespace; first token is the executable, rest are prefix args before the script path. Falls back to built-in defaults for unconfigured extensions. */
-  runners: z.record(z.string(), z.string().trim().min(1)).default({}),
-});
+);
 
 /** Inferred runner configuration type. */
 export type RunnerConfig = z.infer<typeof runnerConfigSchema>;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -36,11 +36,17 @@ function migrateDeprecatedKeys(input: unknown): unknown {
 
   const obj = { ...(input as Record<string, unknown>) };
 
-  // gateway → gatewayUrl
+  // gateway → gatewayUrl / gatewayApiKey
   if ('gateway' in obj && typeof obj.gateway === 'object' && obj.gateway) {
     const gw = obj.gateway as Record<string, unknown>;
     if (!('gatewayUrl' in obj) && 'url' in gw) {
       obj.gatewayUrl = gw.url;
+    }
+    if ('tokenPath' in gw) {
+      console.warn(
+        '[jeeves-runner] DEPRECATED: config key "gateway.tokenPath" (file-based token) has been removed. ' +
+          'Set "gatewayApiKey" to a direct API key string, or use the OPENCLAW_GATEWAY_TOKEN environment variable.',
+      );
     }
     delete obj.gateway;
     console.warn(
@@ -49,8 +55,10 @@ function migrateDeprecatedKeys(input: unknown): unknown {
   }
 
   // log → logging
-  if ('log' in obj && !('logging' in obj)) {
-    obj.logging = obj.log;
+  if ('log' in obj) {
+    if (!('logging' in obj)) {
+      obj.logging = obj.log;
+    }
     delete obj.log;
     console.warn(
       '[jeeves-runner] DEPRECATED: config key "log" is deprecated. Use "logging" instead.',

--- a/packages/service/src/descriptor.test.ts
+++ b/packages/service/src/descriptor.test.ts
@@ -27,7 +27,7 @@ describe('createRunnerDescriptor', () => {
     expect(config).toHaveProperty('port', 1937);
     expect(config).toHaveProperty('maxConcurrency');
     expect(config).toHaveProperty('notifications');
-    expect(config).toHaveProperty('log');
+    expect(config).toHaveProperty('logging');
   });
 
   it('startCommand produces a node CLI invocation', () => {

--- a/packages/service/src/runner.test.ts
+++ b/packages/service/src/runner.test.ts
@@ -36,12 +36,12 @@ function testConfig(dbPath: string, port: number) {
     shutdownGraceMs: 1000,
     runRetentionDays: 30,
     stateCleanupIntervalMs: 3600000,
-    log: { level: 'fatal' as const },
+    logging: { level: 'fatal' as const },
     notifications: {
       defaultOnSuccess: null,
       defaultOnFailure: null,
     },
-    gateway: { url: 'http://127.0.0.1:18789' },
+    gatewayUrl: 'http://127.0.0.1:18789',
     runners: {},
   };
 }

--- a/packages/service/src/runner.ts
+++ b/packages/service/src/runner.ts
@@ -47,7 +47,7 @@ export function createRunner(config: RunnerConfig, deps?: RunnerDeps): Runner {
   let server: FastifyInstance | null = null;
   let maintenance: Maintenance | null = null;
 
-  const logger = deps?.logger ?? pino(buildPinoOptions(config.log));
+  const logger = deps?.logger ?? pino(buildPinoOptions(config.logging));
 
   return {
     async start(): Promise<void> {
@@ -65,13 +65,12 @@ export function createRunner(config: RunnerConfig, deps?: RunnerDeps): Runner {
       const notifier = createNotifier({ slackToken });
 
       // Gateway client (optional, for session-type jobs)
-      const gatewayToken = config.gateway.tokenPath
-        ? readFileSync(config.gateway.tokenPath, 'utf-8').trim()
-        : (process.env.OPENCLAW_GATEWAY_TOKEN ?? null);
+      const gatewayToken =
+        config.gatewayApiKey ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? null;
       const gatewayClient =
-        gatewayToken && config.gateway.url
+        gatewayToken && config.gatewayUrl
           ? createGatewayClient({
-              url: config.gateway.url,
+              url: config.gatewayUrl,
               token: gatewayToken,
             })
           : undefined;
@@ -117,7 +116,7 @@ export function createRunner(config: RunnerConfig, deps?: RunnerDeps): Runner {
         scheduler,
         getConfig: () => config,
         descriptor,
-        logConfig: config.log,
+        logConfig: config.logging,
       });
       let effectiveHost = config.host;
       try {

--- a/packages/service/src/scheduler/scheduler.ts
+++ b/packages/service/src/scheduler/scheduler.ts
@@ -104,7 +104,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
       if (type === 'session') {
         if (!gatewayClient) {
           throw new Error(
-            'Session job requires Gateway client (gateway.tokenPath not configured)',
+            'Session job requires Gateway client (gatewayUrl/gatewayApiKey not configured)',
           );
         }
         result = await executeSession({


### PR DESCRIPTION
Closes #81

## Changes
- Replace nested `gateway.url`/`gateway.tokenPath` with flat `gatewayUrl`/`gatewayApiKey`
- Replace `log.level`/`log.file` with `logging.level`/`logging.file`
- Backward-compat `z.preprocess()` transform accepts old config shape with deprecation warnings
- `gatewayApiKey` is a direct string value (no more file indirection via `tokenPath`)
- Added backward-compat tests in core package

## Migration
Existing configs with the old key names continue to work via automatic transform. New installations should use the new key names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)