### PR TITLE
fix: externalize @karmaniverous/jeeves across core and openclaw packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.5.10.tgz",
-      "integrity": "sha512-8SZGtCVgTzUIqc3q/ABrUxK9yPpYie1s21TUpON1G81VDtPep3VSMOgqU/LnV8NiXNnHDDWkzAbXdGQpa3bLaQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.5.11.tgz",
+      "integrity": "sha512-nb2d/BSqAmDMpTXw8v85PLKNq01f3ukiYITxQVdDAjXchEL95/SXwypHgTdJRNPgvJmkL77BooFXgSJ8qkpHyA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.3",
@@ -1430,7 +1430,7 @@
         "jsonpath-plus": "^10.4.0",
         "package-directory": "^8.2.0",
         "proper-lockfile": "^4.1.2",
-        "semver": "^7.8.0",
+        "semver": "^7.8.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -8396,9 +8396,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9294,7 +9294,7 @@
       "version": "0.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.5.10",
+        "@karmaniverous/jeeves": "^0.5.11",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -9530,12 +9530,14 @@
       "name": "@karmaniverous/jeeves-runner-openclaw",
       "version": "0.7.10",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "@karmaniverous/jeeves": "^0.5.11"
+      },
       "bin": {
         "jeeves-runner-openclaw": "dist/cli.js"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.65.0",
-        "@karmaniverous/jeeves": "^0.5.10",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -9767,10 +9769,10 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-runner",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.5.10",
+        "@karmaniverous/jeeves": "^0.5.11",
         "@karmaniverous/jeeves-runner-core": "^0.1.2",
         "@karmaniverous/rrstack": "^0.17.1",
         "commander": "^14.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.10",
+    "@karmaniverous/jeeves": "^0.5.11",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/core/rollup.config.ts
+++ b/packages/core/rollup.config.ts
@@ -4,11 +4,25 @@
  * Single entry point: src/index.ts → ESM output with declarations.
  */
 
+import { readFileSync } from 'node:fs';
+
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import type { RollupLog, RollupOptions } from 'rollup';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as PackageJson;
+
+const dependencyExternals = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
 
 /** Suppress circular-dependency warnings from node_modules (third-party). */
 function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
@@ -22,7 +36,7 @@ function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
 
 const config: RollupOptions = {
   input: 'src/index.ts',
-  external: [/^node:/],
+  external: [...dependencyExternals, /^node:/],
   onwarn,
   output: {
     dir: 'dist',

--- a/packages/core/rollup.config.ts
+++ b/packages/core/rollup.config.ts
@@ -17,7 +17,9 @@ interface PackageJson {
   peerDependencies?: Record<string, string>;
 }
 
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as PackageJson;
+const pkg = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+) as PackageJson;
 
 const dependencyExternals = [
   ...Object.keys(pkg.dependencies ?? {}),
@@ -36,7 +38,11 @@ function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
 
 const config: RollupOptions = {
   input: 'src/index.ts',
-  external: [...dependencyExternals, /^node:/],
+  external: [
+    ...dependencyExternals,
+    ...dependencyExternals.map((dep) => new RegExp('^' + dep + '/')),
+    /^node:/,
+  ],
   onwarn,
   output: {
     dir: 'dist',

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -48,9 +48,11 @@
       "./dist/index.js"
     ]
   },
+  "dependencies": {
+    "@karmaniverous/jeeves": "^0.5.10"
+  },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.65.0",
-    "@karmaniverous/jeeves": "^0.5.10",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.10"
+    "@karmaniverous/jeeves": "^0.5.11"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.65.0",

--- a/packages/openclaw/rollup.config.ts
+++ b/packages/openclaw/rollup.config.ts
@@ -5,12 +5,26 @@
  * Skills are copied from skills/ → dist/skills/ via rollup-plugin-copy.
  */
 
+import { readFileSync } from 'node:fs';
+
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import type { RollupLog, RollupOptions } from 'rollup';
 import copy from 'rollup-plugin-copy';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as PackageJson;
+
+const dependencyExternals = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
 
 /** Suppress circular-dependency warnings from node_modules (third-party). */
 function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
@@ -24,7 +38,7 @@ function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
 
 const pluginConfig: RollupOptions = {
   input: 'src/index.ts',
-  external: [/^node:/],
+  external: [...dependencyExternals, /^node:/],
   onwarn,
   output: {
     dir: 'dist',
@@ -51,7 +65,7 @@ const pluginConfig: RollupOptions = {
 
 const cliConfig: RollupOptions = {
   input: 'src/cli.ts',
-  external: [/^node:/],
+  external: [...dependencyExternals, /^node:/],
   onwarn,
   output: {
     file: 'dist/cli.js',

--- a/packages/openclaw/rollup.config.ts
+++ b/packages/openclaw/rollup.config.ts
@@ -19,7 +19,9 @@ interface PackageJson {
   peerDependencies?: Record<string, string>;
 }
 
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as PackageJson;
+const pkg = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+) as PackageJson;
 
 const dependencyExternals = [
   ...Object.keys(pkg.dependencies ?? {}),
@@ -38,7 +40,11 @@ function onwarn(warning: RollupLog, defaultHandler: (w: RollupLog) => void) {
 
 const pluginConfig: RollupOptions = {
   input: 'src/index.ts',
-  external: [...dependencyExternals, /^node:/],
+  external: [
+    ...dependencyExternals,
+    ...dependencyExternals.map((dep) => new RegExp('^' + dep + '/')),
+    /^node:/,
+  ],
   onwarn,
   output: {
     dir: 'dist',
@@ -65,7 +71,11 @@ const pluginConfig: RollupOptions = {
 
 const cliConfig: RollupOptions = {
   input: 'src/cli.ts',
-  external: [...dependencyExternals, /^node:/],
+  external: [
+    ...dependencyExternals,
+    ...dependencyExternals.map((dep) => new RegExp('^' + dep + '/')),
+    /^node:/,
+  ],
   onwarn,
   output: {
     file: 'dist/cli.js',

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -46,7 +46,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.10",
+    "@karmaniverous/jeeves": "^0.5.11",
     "@karmaniverous/jeeves-runner-core": "^0.1.2",
     "@karmaniverous/rrstack": "^0.17.1",
     "commander": "^14.0.3",


### PR DESCRIPTION
Closes #85

**Changes:**
- **core/rollup.config.ts:** Read package.json dependencies and add to rollup external array (was only externalizing node: builtins)
- **openclaw/package.json:** Move @karmaniverous/jeeves from devDependencies to dependencies
- **openclaw/rollup.config.ts:** Same externalization pattern applied to both pluginConfig and cliConfig

Follows the existing pattern in service/rollup.config.ts. Build/lint/typecheck all pass.