### PR TITLE
feat: add jobsDir config field and sync-jobs command (#87)

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -113,6 +113,18 @@ describe('runnerConfigSchema', () => {
     warnSpy.mockRestore();
   });
 
+  it('accepts optional jobsDir field', () => {
+    const config = runnerConfigSchema.parse({
+      jobsDir: '/opt/jeeves/scripts/jobs',
+    });
+    expect(config.jobsDir).toBe('/opt/jeeves/scripts/jobs');
+  });
+
+  it('defaults jobsDir to undefined when omitted', () => {
+    const config = runnerConfigSchema.parse({});
+    expect(config.jobsDir).toBeUndefined();
+  });
+
   it('removes deprecated log key even when logging is present', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -101,6 +101,8 @@ export const runnerConfigSchema = z.preprocess(
     gatewayApiKey: z.string().optional(),
     /** Custom command runners keyed by file extension. The command string is split on whitespace; first token is the executable, rest are prefix args before the script path. Falls back to built-in defaults for unconfigured extensions. */
     runners: z.record(z.string(), z.string().trim().min(1)).default({}),
+    /** Absolute path to directory containing job definition files. When omitted, sync-jobs falls back to join(configDir, 'scripts/jobs'). */
+    jobsDir: z.string().optional(),
   }),
 );
 

--- a/packages/service/src/cli/jeeves-runner/config-helpers.ts
+++ b/packages/service/src/cli/jeeves-runner/config-helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared CLI helpers for config loading and database access.
+ *
+ * @module
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { createConnection } from '../../db/connection.js';
+import { runMigrations } from '../../db/migrations.js';
+import { runnerConfigSchema } from '../../schemas/config.js';
+
+/** Load and validate config from a JSON file path, or return defaults. */
+export function loadConfig(configPath?: string) {
+  if (configPath) {
+    const raw = readFileSync(resolve(configPath), 'utf-8');
+    return runnerConfigSchema.parse(JSON.parse(raw));
+  }
+  return runnerConfigSchema.parse({});
+}
+
+/** Open a migrated DB connection, run `fn`, then close. */
+export function withDb<T>(
+  dbPath: string,
+  fn: (db: ReturnType<typeof createConnection>) => T,
+): T {
+  const db = createConnection(dbPath);
+  runMigrations(db);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}

--- a/packages/service/src/cli/jeeves-runner/index.test.ts
+++ b/packages/service/src/cli/jeeves-runner/index.test.ts
@@ -171,6 +171,109 @@ describe('init-scripts command', () => {
   });
 });
 
+describe('sync-jobs command', () => {
+  vi.setConfig({ testTimeout: 15000 });
+  let testDb: TestDb;
+  let configPath: string;
+  let jobsDir: string;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'sync-jobs-test-'));
+    configPath = join(tmpDir, 'config.json');
+    // Jobs dir is at <tmpDir>/scripts/jobs; scripts resolve relative to <tmpDir>/scripts/
+    jobsDir = join(tmpDir, 'scripts', 'jobs');
+    mkdirSync(jobsDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ dbPath: testDb.dbPath, port: 18780 }),
+    );
+  });
+
+  afterEach(() => {
+    testDb.cleanup();
+  });
+
+  it('should sync jobs from a temp directory with valid job definitions', () => {
+    writeFileSync(
+      join(jobsDir, 'batch.json'),
+      JSON.stringify([
+        {
+          id: 'sync-test-1',
+          name: 'Sync Test 1',
+          script: 'hello.ts',
+          schedule: '0 0 * * *',
+          description: 'A synced job',
+        },
+        {
+          id: 'sync-test-2',
+          name: 'Sync Test 2',
+          script: 'world.ts',
+          schedule: '*/5 * * * *',
+          timeout_seconds: 60,
+          enabled: false,
+        },
+      ]),
+    );
+
+    const result = execSync(
+      `node dist/cli/jeeves-runner/index.js sync-jobs --config "${configPath}" --jobs-dir "${jobsDir}"`,
+      { encoding: 'utf-8' },
+    );
+
+    expect(result).toContain('2 added');
+    expect(result).toContain('0 updated');
+    expect(result).toContain('0 skipped');
+
+    const rows = testDb.db
+      .prepare('SELECT * FROM jobs ORDER BY id')
+      .all() as Array<{
+      id: string;
+      name: string;
+      enabled: number;
+      timeout_ms: number | null;
+    }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.id).toBe('sync-test-1');
+    expect(rows[0]?.enabled).toBe(1);
+    expect(rows[1]?.id).toBe('sync-test-2');
+    expect(rows[1]?.enabled).toBe(0);
+    expect(rows[1]?.timeout_ms).toBe(60000);
+  });
+
+  it('should report errors for invalid schedules', () => {
+    writeFileSync(
+      join(jobsDir, 'bad.json'),
+      JSON.stringify([
+        {
+          id: 'bad-schedule',
+          name: 'Bad Schedule',
+          script: 'fail.ts',
+          schedule: 'not-a-cron',
+        },
+      ]),
+    );
+
+    expect(() => {
+      execSync(
+        `node dist/cli/jeeves-runner/index.js sync-jobs --config "${configPath}" --jobs-dir "${jobsDir}"`,
+        { encoding: 'utf-8', stdio: 'pipe' },
+      );
+    }).toThrow();
+  });
+
+  it('should show expected options in --help', () => {
+    const result = execSync(
+      'node dist/cli/jeeves-runner/index.js sync-jobs --help',
+      { encoding: 'utf-8' },
+    );
+    expect(result).toContain('--config');
+    expect(result).toContain('--jobs-dir');
+    expect(result).toContain('--workspace');
+    expect(result).toContain('--config-root');
+  });
+});
+
 describe('shared CLI config flags', () => {
   it('trigger accepts --workspace and --config-root without error', () => {
     // Using --help to avoid actual execution; flags must be recognized.

--- a/packages/service/src/cli/jeeves-runner/index.ts
+++ b/packages/service/src/cli/jeeves-runner/index.ts
@@ -21,34 +21,10 @@ import {
 } from '@karmaniverous/jeeves';
 import type { Command as BaseCommand } from 'commander';
 
-import { createConnection } from '../../db/connection.js';
-import { runMigrations } from '../../db/migrations.js';
 import { createRunnerDescriptor } from '../../descriptor.js';
 import { validateSchedule } from '../../scheduler/schedule-utils.js';
-import { runnerConfigSchema } from '../../schemas/config.js';
-
-/** Load and validate config from a JSON file path, or return defaults. */
-function loadConfig(configPath?: string) {
-  if (configPath) {
-    const raw = readFileSync(resolve(configPath), 'utf-8');
-    return runnerConfigSchema.parse(JSON.parse(raw));
-  }
-  return runnerConfigSchema.parse({});
-}
-
-/** Open a migrated DB connection, run `fn`, then close. */
-function withDb<T>(
-  dbPath: string,
-  fn: (db: ReturnType<typeof createConnection>) => T,
-): T {
-  const db = createConnection(dbPath);
-  runMigrations(db);
-  try {
-    return fn(db);
-  } finally {
-    db.close();
-  }
-}
+import { loadConfig, withDb } from './config-helpers.js';
+import { syncJobs } from './sync-jobs.js';
 
 const descriptor = createRunnerDescriptor({
   customCliCommands: (program: BaseCommand) => {
@@ -256,6 +232,60 @@ const descriptor = createRunnerDescriptor({
           }
 
           console.log('Scripts initialized successfully.');
+        },
+      );
+
+    program
+      .command('sync-jobs')
+      .description('Sync job definitions from JSON files into the database')
+      .option('-c, --config <path>', 'Path to config file')
+      .option('--jobs-dir <dir>', 'Path to jobs directory (overrides config)')
+      .option(
+        '-w, --workspace <path>',
+        'Workspace root path',
+        WORKSPACE_CONFIG_DEFAULTS.core.workspace,
+      )
+      .option(
+        '--config-root <path>',
+        'Platform config root path',
+        WORKSPACE_CONFIG_DEFAULTS.core.configRoot,
+      )
+      .action(
+        (options: {
+          config?: string;
+          jobsDir?: string;
+          workspace: string;
+          configRoot: string;
+        }) => {
+          init({
+            workspacePath: options.workspace,
+            configRoot: options.configRoot,
+          });
+
+          const config = loadConfig(options.config);
+          const configDir = options.config
+            ? dirname(resolve(options.config))
+            : getComponentConfigDir('runner');
+          const resolvedJobsDir =
+            options.jobsDir ??
+            config.jobsDir ??
+            join(configDir, 'scripts/jobs');
+
+          withDb(config.dbPath, (db) => {
+            const syncResult = syncJobs(db, resolvedJobsDir);
+
+            console.log(
+              `Sync complete: ${String(syncResult.added)} added, ${String(syncResult.updated)} updated, ${String(syncResult.skipped)} skipped`,
+            );
+
+            if (syncResult.errors.length > 0) {
+              console.error('Errors:');
+              for (const e of syncResult.errors) {
+                console.error(`  - ${e}`);
+              }
+              process.exit(1);
+            }
+          });
         },
       );
   },

--- a/packages/service/src/cli/jeeves-runner/sync-jobs.ts
+++ b/packages/service/src/cli/jeeves-runner/sync-jobs.ts
@@ -1,0 +1,158 @@
+/**
+ * Sync job definitions from JSON files into the runner database.
+ *
+ * @module
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
+
+import { validateSchedule } from '../../scheduler/schedule-utils.js';
+
+/** Shape of a single job definition in a JSON file. */
+interface JobDefinition {
+  id: string;
+  name: string;
+  script: string;
+  schedule: string | Record<string, unknown>;
+  description?: string;
+  overlap_policy?: 'skip' | 'allow';
+  timeout_seconds?: number;
+  enabled?: boolean;
+  type?: 'script' | 'session';
+  on_failure?: string | null;
+  on_success?: string | null;
+  output_channel?: string | null;
+  source_type?: 'path' | 'inline';
+  domain?: string;
+  prerequisite?: string | null;
+}
+
+/** Result counts from a sync operation. */
+export interface SyncResult {
+  added: number;
+  updated: number;
+  skipped: number;
+  errors: string[];
+}
+
+/**
+ * Sync all job definitions from JSON files in `jobsDir` into the database.
+ *
+ * Each JSON file must contain an array of job objects. Script paths are
+ * resolved relative to the parent of `jobsDir`.
+ */
+export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
+  const resolvedDir = resolve(jobsDir);
+  const scriptsRoot = resolve(resolvedDir, '..');
+  const result: SyncResult = { added: 0, updated: 0, skipped: 0, errors: [] };
+
+  let files: string[];
+  try {
+    files = readdirSync(resolvedDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    result.errors.push(`Cannot read jobs directory: ${resolvedDir}`);
+    return result;
+  }
+
+  if (files.length === 0) {
+    console.log(`No JSON files found in ${resolvedDir}`);
+    return result;
+  }
+
+  // Track existing job IDs to determine add vs update
+  const existingIds = new Set(
+    (db.prepare('SELECT id FROM jobs').all() as Array<{ id: string }>).map(
+      (r) => r.id,
+    ),
+  );
+
+  const stmt = db.prepare(
+    `INSERT OR REPLACE INTO jobs
+       (id, name, schedule, script, type, description, enabled, timeout_ms,
+        overlap_policy, on_failure, on_success, output_channel, source_type, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+  );
+
+  for (const file of files) {
+    const filePath = join(resolvedDir, file);
+    let jobs: unknown;
+
+    try {
+      jobs = JSON.parse(readFileSync(filePath, 'utf-8'));
+    } catch (err) {
+      result.errors.push(
+        `Failed to parse ${file}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      result.skipped++;
+      continue;
+    }
+
+    if (!Array.isArray(jobs)) {
+      result.errors.push(`${file}: expected an array of job definitions`);
+      result.skipped++;
+      continue;
+    }
+
+    for (const raw of jobs as unknown[]) {
+      if (typeof raw !== 'object' || raw === null) {
+        result.errors.push(`${file}: job entry is not an object`);
+        result.skipped++;
+        continue;
+      }
+
+      const obj = raw as Record<string, unknown>;
+      if (!obj.id || !obj.name || !obj.script || obj.schedule == null) {
+        result.errors.push(
+          `${file}: job missing required fields (id, name, script, schedule)`,
+        );
+        result.skipped++;
+        continue;
+      }
+
+      const job = obj as unknown as JobDefinition;
+      const scheduleStr =
+        typeof job.schedule === 'object'
+          ? JSON.stringify(job.schedule)
+          : job.schedule;
+
+      const validation = validateSchedule(scheduleStr);
+      if (!validation.valid) {
+        result.errors.push(
+          `${file}: job '${job.id}' has invalid schedule: ${validation.error}`,
+        );
+        result.skipped++;
+        continue;
+      }
+
+      const scriptPath = resolve(scriptsRoot, job.script);
+      const isUpdate = existingIds.has(job.id);
+
+      stmt.run(
+        job.id,
+        job.name,
+        scheduleStr,
+        scriptPath,
+        job.type ?? 'script',
+        job.description ?? null,
+        (job.enabled ?? true) ? 1 : 0,
+        job.timeout_seconds != null ? job.timeout_seconds * 1000 : null,
+        job.overlap_policy ?? 'skip',
+        job.on_failure ?? null,
+        job.on_success ?? null,
+        job.output_channel ?? null,
+        job.source_type ?? 'path',
+      );
+
+      if (isUpdate) {
+        result.updated++;
+      } else {
+        result.added++;
+        existingIds.add(job.id);
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/service/src/cli/jeeves-runner/sync-jobs.ts
+++ b/packages/service/src/cli/jeeves-runner/sync-jobs.ts
@@ -69,10 +69,24 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
   );
 
   const stmt = db.prepare(
-    `INSERT OR REPLACE INTO jobs
+    `INSERT INTO jobs
        (id, name, schedule, script, type, description, enabled, timeout_ms,
         overlap_policy, on_failure, on_success, output_channel, source_type, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(id) DO UPDATE SET
+       name = excluded.name,
+       schedule = excluded.schedule,
+       script = excluded.script,
+       type = excluded.type,
+       description = excluded.description,
+       enabled = excluded.enabled,
+       timeout_ms = excluded.timeout_ms,
+       overlap_policy = excluded.overlap_policy,
+       on_failure = excluded.on_failure,
+       on_success = excluded.on_success,
+       output_channel = excluded.output_channel,
+       source_type = excluded.source_type,
+       updated_at = datetime('now')`,
   );
 
   for (const file of files) {
@@ -103,15 +117,40 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
       }
 
       const obj = raw as Record<string, unknown>;
-      if (!obj.id || !obj.name || !obj.script || obj.schedule == null) {
+      if (
+        typeof obj.id !== 'string' ||
+        typeof obj.name !== 'string' ||
+        typeof obj.script !== 'string' ||
+        obj.schedule == null
+      ) {
         result.errors.push(
-          `${file}: job missing required fields (id, name, script, schedule)`,
+          `${file}: job missing or has invalid required fields (id, name, script must be strings, schedule must be defined)`,
         );
         result.skipped++;
         continue;
       }
 
       const job = obj as unknown as JobDefinition;
+
+      if (
+        job.timeout_seconds != null &&
+        typeof job.timeout_seconds !== 'number'
+      ) {
+        result.errors.push(
+          `${file}: job '${job.id}' has invalid timeout_seconds (must be a number)`,
+        );
+        result.skipped++;
+        continue;
+      }
+
+      if (job.enabled != null && typeof job.enabled !== 'boolean') {
+        result.errors.push(
+          `${file}: job '${job.id}' has invalid enabled field (must be a boolean)`,
+        );
+        result.skipped++;
+        continue;
+      }
+
       const scheduleStr =
         typeof job.schedule === 'object'
           ? JSON.stringify(job.schedule)
@@ -126,7 +165,10 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
         continue;
       }
 
-      const scriptPath = resolve(scriptsRoot, job.script);
+      const scriptPath =
+        (job.source_type ?? 'path') === 'path'
+          ? resolve(scriptsRoot, job.script)
+          : job.script;
       const isUpdate = existingIds.has(job.id);
 
       stmt.run(


### PR DESCRIPTION
Closes #87

## Changes

### 1. `jobsDir` config field (packages/core)
- Added optional `jobsDir` field to `runnerConfigSchema`
- Accepts an absolute path to the directory containing job definition JSON files
- Falls back to `join(configDir, 'scripts/jobs')` when omitted

### 2. `sync-jobs` CLI command (packages/service)
- New CLI command that reads `*.json` files from the jobs directory
- Each JSON file contains an array of job definitions
- Upserts (INSERT OR REPLACE) each job into the SQLite database
- Validates schedules using `validateSchedule()`
- Resolves relative script paths against the parent of the jobs directory
- Reports added/updated/skipped counts and errors
- Supports `--config`, `--jobs-dir`, `--workspace`, `--config-root` options
- `--jobs-dir` overrides `config.jobsDir` which overrides the default

### 3. Code organization
- Extracted shared `loadConfig` and `withDb` helpers into `config-helpers.ts`

## Testing
- All 163 tests pass (10 core + 27 openclaw + 126 service, including 3 new sync-jobs tests)
- Lint clean, typecheck clean, build clean