### PR TITLE
[77][89] feat: endpoint catalog, canonical schemas, per-job env/args

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,13 +393,14 @@ Config file: `jeeves-runner/config.json` (legacy `jeeves-runner.config.json` is 
 | `reconcileIntervalMs` | number | `60000` | Job reconciliation interval (ms) |
 | `shutdownGraceMs` | number | `30000` | Grace period for running jobs on shutdown |
 | `runners` | Record | `{}` | Custom command runners keyed by file extension |
-| `gateway.url` | string | `http://127.0.0.1:18789` | OpenClaw Gateway URL (for session jobs) |
-| `gateway.tokenPath` | string | — | Path to gateway auth token file |
+| `gatewayUrl` | string | `http://127.0.0.1:18789` | OpenClaw Gateway URL (for session jobs) |
+| `gatewayApiKey` | string | — | Gateway API key (falls back to `OPENCLAW_GATEWAY_TOKEN` env var) |
+| `jobsDir` | string | — | Directory containing job definition JSON files (for `sync-jobs`) |
 | `notifications.slackTokenPath` | string | — | Path to Slack bot token file |
 | `notifications.defaultOnFailure` | string \| null | `null` | Default Slack channel for failures |
 | `notifications.defaultOnSuccess` | string \| null | `null` | Default Slack channel for successes |
-| `log.level` | string | `info` | Log level (trace/debug/info/warn/error/fatal) |
-| `log.file` | string | — | Log file path (stdout if omitted) |
+| `logging.level` | string | `info` | Log level (trace/debug/info/warn/error/fatal) |
+| `logging.file` | string | — | Log file path (stdout if omitted) |
 
 ## OpenClaw Plugin
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,14 @@ Or create `jeeves-runner/config.json` manually:
   "runners": {
     "ts": "node ./scripts/node_modules/tsx/dist/cli.mjs"
   },
-  "gateway": {
-    "url": "http://127.0.0.1:18789",
-    "tokenPath": "./credentials/gateway-token"
-  },
+  "gatewayUrl": "http://127.0.0.1:18789",
+  "gatewayApiKey": "your-api-key-or-use-OPENCLAW_GATEWAY_TOKEN-env",
   "notifications": {
     "slackTokenPath": "./credentials/slack-bot-token",
     "defaultOnFailure": "YOUR_SLACK_CHANNEL_ID",
     "defaultOnSuccess": null
   },
-  "log": {
+  "logging": {
     "level": "info",
     "file": "./data/runner.log"
   }
@@ -139,6 +137,7 @@ Built with `createServiceCli(descriptor)` from core. Standard commands plus cust
 | `list-jobs` | List all configured jobs |
 | `trigger` | Manually trigger a job run (queries the HTTP API) |
 | `init-scripts` | Scaffold a scripts project from the template |
+| `sync-jobs` | Sync job definitions from JSON files into the database |
 
 ## HTTP API
 
@@ -204,6 +203,11 @@ Each job has an ID, name, cron schedule, script path, and behavioral configurati
 | `overlap_policy` | TEXT | `skip` (default) or `allow` |
 | `on_failure` | TEXT | Slack channel ID for failure alerts |
 | `on_success` | TEXT | Slack channel ID for success alerts |
+| `output_channel` | TEXT | Slack channel ID for stdout relay |
+| `source_type` | TEXT | `path` (file reference) or `inline` (script content) |
+| `description` | TEXT | Human-readable description |
+| `env` | TEXT | JSON `Record<string, string>` — per-job env vars (script-type only) |
+| `args` | TEXT | JSON `string[]` — per-job arguments (script-type only) |
 
 ### `runs` — Run History
 
@@ -220,7 +224,7 @@ Every execution is recorded with status, timing, output capture, and optional to
 | `result_meta` | TEXT | JSON from `JR_RESULT:{json}` stdout lines |
 | `stdout_tail` | TEXT | Last 100 lines of stdout |
 | `stderr_tail` | TEXT | Last 100 lines of stderr |
-| `trigger` | TEXT | `schedule`, `manual`, or `retry` |
+| `trigger` | TEXT | `schedule` or `manual` |
 
 Runs older than `runRetentionDays` are automatically pruned.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9528,10 +9528,11 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-runner-openclaw",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.5.11"
+        "@karmaniverous/jeeves": "^0.5.11",
+        "@karmaniverous/jeeves-runner-core": "^0.1.5"
       },
       "bin": {
         "jeeves-runner-openclaw": "dist/cli.js"
@@ -9769,7 +9770,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-runner",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.12",

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared HTTP response contracts between service and plugin.
+ *
+ * These types define the shape of responses from the jeeves-runner service
+ * HTTP API, consumed by both the service route handlers and the OpenClaw
+ * plugin client.
+ */
+
+import type { Job } from './schemas.js';
+
+/** Job row with last run metadata, as returned by GET /jobs. */
+export interface JobListItem extends Job {
+  /** Status of the most recent run (null if never run). */
+  last_status: string | null;
+  /** ISO timestamp of the most recent run start (null if never run). */
+  last_run: string | null;
+}
+
+/** GET /jobs response envelope. */
+export interface JobsResponse {
+  jobs: JobListItem[];
+}
+
+/** GET /jobs/:id response envelope. */
+export interface JobDetailResponse {
+  job: Job;
+}
+
+/** Run record as returned by the API (snake_case DB columns). */
+export interface RunRecord {
+  id: number;
+  job_id: string;
+  status: string;
+  started_at: string | null;
+  finished_at: string | null;
+  duration_ms: number | null;
+  exit_code: number | null;
+  tokens: number | null;
+  result_meta: string | null;
+  error: string | null;
+  stdout_tail: string | null;
+  stderr_tail: string | null;
+  trigger: string;
+}
+
+/** GET /jobs/:id/runs response envelope. */
+export interface RunsResponse {
+  runs: RunRecord[];
+}
+
+/** GET /queues/:name/status response. */
+export interface QueueStatusResponse {
+  queue: string;
+  pending: number;
+  processing: number;
+  done: number;
+  failed: number;
+  oldest_pending_age_ms: number | null;
+}
+
+/** Queue peek item. */
+export interface QueuePeekItem {
+  id: number;
+  payload: unknown;
+  priority: number;
+  createdAt: string;
+}
+
+/** GET /queues/:name/peek response envelope. */
+export interface QueuePeekResponse {
+  items: QueuePeekItem[];
+}

--- a/packages/core/src/endpoints.test.ts
+++ b/packages/core/src/endpoints.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { getEndpoint, RUNNER_ENDPOINTS } from './endpoints.js';
+
+describe('RUNNER_ENDPOINTS', () => {
+  it('should have 19 endpoints', () => {
+    expect(RUNNER_ENDPOINTS).toHaveLength(19);
+  });
+
+  it('should have unique names', () => {
+    const names = RUNNER_ENDPOINTS.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('should have non-empty descriptions', () => {
+    for (const ep of RUNNER_ENDPOINTS) {
+      expect(ep.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should have valid HTTP methods', () => {
+    const validMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+    for (const ep of RUNNER_ENDPOINTS) {
+      expect(validMethods.has(ep.method)).toBe(true);
+    }
+  });
+
+  it('should have paths starting with /', () => {
+    for (const ep of RUNNER_ENDPOINTS) {
+      expect(ep.path.startsWith('/')).toBe(true);
+    }
+  });
+});
+
+describe('getEndpoint', () => {
+  it('should return the correct endpoint by name', () => {
+    const ep = getEndpoint('status');
+    expect(ep.method).toBe('GET');
+    expect(ep.path).toBe('/status');
+  });
+
+  it('should return createJob endpoint', () => {
+    const ep = getEndpoint('createJob');
+    expect(ep.method).toBe('POST');
+    expect(ep.path).toBe('/jobs');
+  });
+
+  it('should return deleteJob endpoint', () => {
+    const ep = getEndpoint('deleteJob');
+    expect(ep.method).toBe('DELETE');
+    expect(ep.path).toBe('/jobs/:id');
+  });
+
+  it('should throw for unknown endpoint', () => {
+    expect(() =>
+      getEndpoint('nonexistent' as Parameters<typeof getEndpoint>[0]),
+    ).toThrow('Unknown endpoint: nonexistent');
+  });
+});

--- a/packages/core/src/endpoints.test.ts
+++ b/packages/core/src/endpoints.test.ts
@@ -18,13 +18,6 @@ describe('RUNNER_ENDPOINTS', () => {
     }
   });
 
-  it('should have valid HTTP methods', () => {
-    const validMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
-    for (const ep of RUNNER_ENDPOINTS) {
-      expect(validMethods.has(ep.method)).toBe(true);
-    }
-  });
-
   it('should have paths starting with /', () => {
     for (const ep of RUNNER_ENDPOINTS) {
       expect(ep.path.startsWith('/')).toBe(true);

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared endpoint catalog — single source of truth for the jeeves-runner API.
+ *
+ * Both the CLI service and the OpenClaw plugin derive their registrations
+ * from this declarative catalog, eliminating drift between the two.
+ */
+
+/** HTTP methods used by the API. */
+export type HttpMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
+
+/** Descriptor for a single API endpoint. */
+export interface EndpointDescriptor {
+  /** Unique endpoint identifier (camelCase). */
+  name: string;
+  /** HTTP method. */
+  method: HttpMethod;
+  /** URL path pattern (e.g. '/jobs/:id'). */
+  path: string;
+  /** Human-readable description of the endpoint's purpose. */
+  description: string;
+}
+
+/**
+ * Canonical endpoint catalog for the jeeves-runner API.
+ *
+ * Every entry describes a single HTTP endpoint exposed by the service.
+ * Route handlers, plugin tools, and HTTP clients should reference these
+ * descriptors rather than hard-coding paths and descriptions.
+ */
+export const RUNNER_ENDPOINTS = [
+  {
+    name: 'status',
+    method: 'GET',
+    path: '/status',
+    description:
+      'Unified status: version, uptime, total/running jobs, failed registrations, OK/error counts last hour',
+  },
+  {
+    name: 'listJobs',
+    method: 'GET',
+    path: '/jobs',
+    description: 'List all jobs with last run status',
+  },
+  {
+    name: 'createJob',
+    method: 'POST',
+    path: '/jobs',
+    description: 'Create a new job',
+  },
+  {
+    name: 'jobDetail',
+    method: 'GET',
+    path: '/jobs/:id',
+    description: 'Single job detail',
+  },
+  {
+    name: 'updateJob',
+    method: 'PATCH',
+    path: '/jobs/:id',
+    description: 'Partial update of job config',
+  },
+  {
+    name: 'deleteJob',
+    method: 'DELETE',
+    path: '/jobs/:id',
+    description: 'Remove a job and its runs',
+  },
+  {
+    name: 'enableJob',
+    method: 'PATCH',
+    path: '/jobs/:id/enable',
+    description: 'Enable a job',
+  },
+  {
+    name: 'disableJob',
+    method: 'PATCH',
+    path: '/jobs/:id/disable',
+    description: 'Disable a job',
+  },
+  {
+    name: 'updateScript',
+    method: 'PUT',
+    path: '/jobs/:id/script',
+    description: 'Update job script (path or inline)',
+  },
+  {
+    name: 'triggerJob',
+    method: 'POST',
+    path: '/jobs/:id/run',
+    description: 'Trigger manual run',
+  },
+  {
+    name: 'jobRuns',
+    method: 'GET',
+    path: '/jobs/:id/runs',
+    description: 'Run history (limit param)',
+  },
+  {
+    name: 'config',
+    method: 'GET',
+    path: '/config',
+    description: 'Query effective configuration (optional JSONPath)',
+  },
+  {
+    name: 'configApply',
+    method: 'POST',
+    path: '/config/apply',
+    description:
+      'Apply a config patch (validates, merges, writes, triggers reconciliation)',
+  },
+  {
+    name: 'listQueues',
+    method: 'GET',
+    path: '/queues',
+    description: 'List all queue names',
+  },
+  {
+    name: 'queueStatus',
+    method: 'GET',
+    path: '/queues/:name/status',
+    description: 'Queue depth, claimed, failed, oldest age',
+  },
+  {
+    name: 'queuePeek',
+    method: 'GET',
+    path: '/queues/:name/peek',
+    description: 'Peek at pending items (optional limit)',
+  },
+  {
+    name: 'listNamespaces',
+    method: 'GET',
+    path: '/state',
+    description: 'List all state namespaces',
+  },
+  {
+    name: 'queryState',
+    method: 'GET',
+    path: '/state/:namespace',
+    description: 'Scalar state (optional JSONPath)',
+  },
+  {
+    name: 'queryCollection',
+    method: 'GET',
+    path: '/state/:namespace/:key',
+    description: 'Collection items (optional JSONPath, limit, order)',
+  },
+] as const satisfies readonly EndpointDescriptor[];
+
+/** Union of all endpoint names. */
+export type EndpointName = (typeof RUNNER_ENDPOINTS)[number]['name'];
+
+/** Single entry from the catalog, narrowed by name. */
+export type Endpoint<N extends EndpointName> = Extract<
+  (typeof RUNNER_ENDPOINTS)[number],
+  { name: N }
+>;
+
+/**
+ * Look up an endpoint descriptor by name.
+ *
+ * @param name - The endpoint identifier.
+ * @returns The matching {@link EndpointDescriptor}.
+ */
+export function getEndpoint<N extends EndpointName>(name: N): Endpoint<N> {
+  const ep = RUNNER_ENDPOINTS.find((e) => e.name === name);
+  if (!ep) throw new Error(`Unknown endpoint: ${name}`);
+  return ep as Endpoint<N>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,52 @@
 /**
- * Shared configuration schema and types for jeeves-runner packages.
+ * Shared configuration schema, endpoint catalog, and entity schemas
+ * for jeeves-runner packages.
  *
  * @packageDocumentation
  */
 
+// Configuration
 export { type RunnerConfig, runnerConfigSchema } from './config.js';
+
+// Contracts (shared response types)
+export type {
+  JobDetailResponse,
+  JobListItem,
+  JobsResponse,
+  QueuePeekItem,
+  QueuePeekResponse,
+  QueueStatusResponse,
+  RunRecord,
+  RunsResponse,
+} from './contracts.js';
+
+// Endpoints
+export type {
+  Endpoint,
+  EndpointDescriptor,
+  EndpointName,
+  HttpMethod,
+} from './endpoints.js';
+export { getEndpoint, RUNNER_ENDPOINTS } from './endpoints.js';
+
+// Schemas
+export type {
+  CreateJob,
+  Job,
+  Queue,
+  Run,
+  RunStatus,
+  RunTrigger,
+  UpdateJob,
+  UpdateScript,
+} from './schemas.js';
+export {
+  createJobSchema,
+  jobSchema,
+  queueSchema,
+  runSchema,
+  runStatusSchema,
+  runTriggerSchema,
+  updateJobSchema,
+  updateScriptSchema,
+} from './schemas.js';

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createJobSchema,
+  jobSchema,
+  queueSchema,
+  runSchema,
+  runTriggerSchema,
+  updateJobSchema,
+  updateScriptSchema,
+} from './schemas.js';
+
+describe('jobSchema', () => {
+  it('should parse a minimal job', () => {
+    const result = jobSchema.parse({
+      id: 'test-job',
+      name: 'Test Job',
+      schedule: '*/5 * * * *',
+      script: '/path/to/script.ts',
+    });
+    expect(result.id).toBe('test-job');
+    expect(result.type).toBe('script');
+    expect(result.enabled).toBe(true);
+    expect(result.overlapPolicy).toBe('skip');
+    expect(result.sourceType).toBe('path');
+    expect(result.onFailure).toBeNull();
+    expect(result.onSuccess).toBeNull();
+    expect(result.outputChannel).toBeNull();
+    expect(result.env).toBeUndefined();
+    expect(result.args).toBeUndefined();
+  });
+
+  it('should parse a job with env and args', () => {
+    const result = jobSchema.parse({
+      id: 'env-job',
+      name: 'Env Job',
+      schedule: '0 * * * *',
+      script: 'briefing.ts',
+      env: { CUSTOMER: 'veterancrowd', MODE: 'live' },
+      args: ['--customer', 'veterancrowd', '--live'],
+    });
+    expect(result.env).toEqual({ CUSTOMER: 'veterancrowd', MODE: 'live' });
+    expect(result.args).toEqual(['--customer', 'veterancrowd', '--live']);
+  });
+
+  it('should parse a job with all optional fields', () => {
+    const result = jobSchema.parse({
+      id: 'full-job',
+      name: 'Full Job',
+      schedule: '0 0 * * *',
+      script: 'inline code',
+      type: 'session',
+      description: 'A full job',
+      enabled: false,
+      timeoutMs: 30000,
+      overlapPolicy: 'allow',
+      sourceType: 'inline',
+      onFailure: 'C123',
+      onSuccess: 'C456',
+      outputChannel: 'C789',
+      env: { KEY: 'value' },
+      args: ['--flag'],
+    });
+    expect(result.type).toBe('session');
+    expect(result.sourceType).toBe('inline');
+    expect(result.outputChannel).toBe('C789');
+  });
+});
+
+describe('createJobSchema', () => {
+  it('should parse a minimal create request', () => {
+    const result = createJobSchema.parse({
+      id: 'new-job',
+      name: 'New Job',
+      schedule: '*/10 * * * *',
+      script: '/path/to/script.ts',
+    });
+    expect(result.source_type).toBe('path');
+    expect(result.type).toBe('script');
+    expect(result.overlap_policy).toBe('skip');
+    expect(result.enabled).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    const result = createJobSchema.safeParse({ id: 'x' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept env and args', () => {
+    const result = createJobSchema.parse({
+      id: 'env-job',
+      name: 'Env Job',
+      schedule: '0 * * * *',
+      script: 'test.ts',
+      env: { FOO: 'bar' },
+      args: ['--live'],
+    });
+    expect(result.env).toEqual({ FOO: 'bar' });
+    expect(result.args).toEqual(['--live']);
+  });
+
+  it('should accept output_channel', () => {
+    const result = createJobSchema.parse({
+      id: 'oc-job',
+      name: 'OC Job',
+      schedule: '0 * * * *',
+      script: 'test.ts',
+      output_channel: 'C123',
+    });
+    expect(result.output_channel).toBe('C123');
+  });
+});
+
+describe('updateJobSchema', () => {
+  it('should accept partial updates', () => {
+    const result = updateJobSchema.parse({ name: 'Updated Name' });
+    expect(result.name).toBe('Updated Name');
+  });
+
+  it('should accept empty object (defaults applied)', () => {
+    const result = updateJobSchema.parse({});
+    // Partial schema still applies defaults for fields with .default()
+    expect(result.source_type).toBe('path');
+    expect(result.type).toBe('script');
+    expect(result.overlap_policy).toBe('skip');
+    expect(result.enabled).toBe(true);
+  });
+
+  it('should accept env and args updates', () => {
+    const result = updateJobSchema.parse({
+      env: { NEW_VAR: 'value' },
+      args: ['--new-flag'],
+    });
+    expect(result.env).toEqual({ NEW_VAR: 'value' });
+    expect(result.args).toEqual(['--new-flag']);
+  });
+});
+
+describe('updateScriptSchema', () => {
+  it('should parse script-only update', () => {
+    const result = updateScriptSchema.parse({ script: '/new/path.ts' });
+    expect(result.script).toBe('/new/path.ts');
+    expect(result.source_type).toBeUndefined();
+  });
+
+  it('should parse script with source_type', () => {
+    const result = updateScriptSchema.parse({
+      script: 'console.log("hi")',
+      source_type: 'inline',
+    });
+    expect(result.source_type).toBe('inline');
+  });
+});
+
+describe('runSchema', () => {
+  it('should parse a minimal run', () => {
+    const result = runSchema.parse({
+      id: 1,
+      jobId: 'test-job',
+      status: 'ok',
+    });
+    expect(result.trigger).toBe('schedule');
+  });
+
+  it('should accept manual trigger', () => {
+    const result = runSchema.parse({
+      id: 2,
+      jobId: 'test-job',
+      status: 'running',
+      trigger: 'manual',
+    });
+    expect(result.trigger).toBe('manual');
+  });
+
+  it('should reject retry trigger (removed per DD#46)', () => {
+    const result = runTriggerSchema.safeParse('retry');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('queueSchema', () => {
+  it('should parse a minimal queue', () => {
+    const result = queueSchema.parse({
+      id: 'test-queue',
+      name: 'Test Queue',
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    expect(result.dedupScope).toBe('pending');
+    expect(result.maxAttempts).toBe(1);
+    expect(result.retentionDays).toBe(7);
+  });
+});

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,0 +1,199 @@
+/**
+ * Canonical Zod schemas for jeeves-runner entities.
+ *
+ * Single source of truth for job, run, and queue schemas. Both the service
+ * package and the OpenClaw plugin derive their validation from these.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Job
+// ---------------------------------------------------------------------------
+
+/** Job definition schema for scheduled tasks. */
+export const jobSchema = z.object({
+  /** Unique job identifier. */
+  id: z.string(),
+  /** Human-readable job name. */
+  name: z.string(),
+  /** Cron or RRStack schedule expression. */
+  schedule: z.string(),
+  /** Script path or command to execute. */
+  script: z.string(),
+  /** Job execution type (script or session). */
+  type: z.enum(['script', 'session']).default('script'),
+  /** Optional job description. */
+  description: z.string().optional(),
+  /** Whether the job is enabled for scheduling. */
+  enabled: z.boolean().default(true),
+  /** Optional execution timeout in milliseconds. */
+  timeoutMs: z.number().optional(),
+  /** Policy for handling overlapping job executions (skip or allow). */
+  overlapPolicy: z.enum(['skip', 'allow']).default('skip'),
+  /** Script source type: 'path' uses script as file path, 'inline' treats script as source code. */
+  sourceType: z.enum(['path', 'inline']).default('path'),
+  /** Slack channel ID for failure notifications. */
+  onFailure: z.string().nullable().default(null),
+  /** Slack channel ID for success notifications. */
+  onSuccess: z.string().nullable().default(null),
+  /** Output channel identifier for routing session results. */
+  outputChannel: z.string().nullable().default(null),
+  /** Optional environment variables for script-type jobs. Spread into spawn env alongside JR_* vars. Ignored for session-type jobs. */
+  env: z.record(z.string(), z.string()).optional(),
+  /** Optional arguments for script-type jobs. Appended after the script path in the spawn call. Ignored for session-type jobs. */
+  args: z.array(z.string()).optional(),
+});
+
+/** Inferred Job type from schema. */
+export type Job = z.infer<typeof jobSchema>;
+
+// ---------------------------------------------------------------------------
+// Job API schemas (create / update / script)
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema for job creation request body.
+ *
+ * Uses snake_case field names to match the HTTP API convention. Required
+ * fields: id, name, schedule, script. All others are optional with defaults.
+ */
+export const createJobSchema = z.object({
+  /** Unique job identifier. */
+  id: z.string().min(1),
+  /** Human-readable job name. */
+  name: z.string().min(1),
+  /** Cron or RRStack schedule expression. */
+  schedule: z.string().min(1),
+  /** Script path or command to execute. */
+  script: z.string().min(1),
+  /** Script source type: 'path' (file path) or 'inline' (source code). */
+  source_type: z.enum(['path', 'inline']).default('path'),
+  /** Job execution type (script or session). */
+  type: z.enum(['script', 'session']).default('script'),
+  /** Timeout in seconds (converted to timeout_ms internally). */
+  timeout_seconds: z.number().positive().optional(),
+  /** Policy for handling overlapping job executions. */
+  overlap_policy: z.enum(['skip', 'allow']).default('skip'),
+  /** Whether the job is enabled for scheduling. */
+  enabled: z.boolean().default(true),
+  /** Optional job description. */
+  description: z.string().optional(),
+  /** Slack channel ID for failure notifications. */
+  on_failure: z.string().nullable().optional(),
+  /** Slack channel ID for success notifications. */
+  on_success: z.string().nullable().optional(),
+  /** Output channel identifier for routing session results. */
+  output_channel: z.string().nullable().optional(),
+  /** Optional environment variables for script-type jobs. */
+  env: z.record(z.string(), z.string()).optional(),
+  /** Optional arguments for script-type jobs. */
+  args: z.array(z.string()).optional(),
+});
+
+/** Inferred CreateJob type from schema. */
+export type CreateJob = z.infer<typeof createJobSchema>;
+
+/**
+ * Zod schema for job update request body (all fields optional except id omitted).
+ */
+export const updateJobSchema = createJobSchema.omit({ id: true }).partial();
+
+/** Inferred UpdateJob type from schema. */
+export type UpdateJob = z.infer<typeof updateJobSchema>;
+
+/**
+ * Zod schema for script update request body.
+ */
+export const updateScriptSchema = z.object({
+  /** New script content (path or inline source). */
+  script: z.string().min(1),
+  /** Optional source type override. */
+  source_type: z.enum(['path', 'inline']).optional(),
+});
+
+/** Inferred UpdateScript type from schema. */
+export type UpdateScript = z.infer<typeof updateScriptSchema>;
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+/** Run status enumeration schema. */
+export const runStatusSchema = z.enum([
+  'pending',
+  'running',
+  'ok',
+  'error',
+  'timeout',
+  'skipped',
+]);
+
+/** Run trigger type enumeration schema. */
+export const runTriggerSchema = z.enum(['schedule', 'manual']);
+
+/** Run record schema representing a job execution instance. */
+export const runSchema = z.object({
+  /** Unique run identifier. */
+  id: z.number(),
+  /** Reference to the parent job ID. */
+  jobId: z.string(),
+  /** Current execution status. */
+  status: runStatusSchema,
+  /** ISO timestamp when execution started. */
+  startedAt: z.string().optional(),
+  /** ISO timestamp when execution finished. */
+  finishedAt: z.string().optional(),
+  /** Execution duration in milliseconds. */
+  durationMs: z.number().optional(),
+  /** Process exit code. */
+  exitCode: z.number().optional(),
+  /** Token count for session-type jobs. */
+  tokens: z.number().optional(),
+  /** Additional result metadata (JSON string). */
+  resultMeta: z.string().optional(),
+  /** Error message if execution failed. */
+  error: z.string().optional(),
+  /** Last N characters of stdout. */
+  stdoutTail: z.string().optional(),
+  /** Last N characters of stderr. */
+  stderrTail: z.string().optional(),
+  /** What triggered this run (schedule or manual). */
+  trigger: runTriggerSchema.default('schedule'),
+});
+
+/** Inferred Run type representing a job execution record. */
+export type Run = z.infer<typeof runSchema>;
+
+/** Inferred RunStatus type from schema. */
+export type RunStatus = z.infer<typeof runStatusSchema>;
+
+/** Inferred RunTrigger type from schema. */
+export type RunTrigger = z.infer<typeof runTriggerSchema>;
+
+// ---------------------------------------------------------------------------
+// Queue
+// ---------------------------------------------------------------------------
+
+/** Queue definition schema for managing queue behavior and retention. */
+export const queueSchema = z.object({
+  /** Unique queue identifier. */
+  id: z.string(),
+  /** Human-readable queue name. */
+  name: z.string(),
+  /** Optional queue description. */
+  description: z.string().nullable().optional(),
+  /** JSONPath expression for deduplication key extraction. */
+  dedupExpr: z.string().nullable().optional(),
+  /** Deduplication scope: 'pending' checks pending/processing items, 'all' checks all non-failed items. */
+  dedupScope: z.enum(['pending', 'all']).default('pending'),
+  /** Maximum retry attempts before dead-lettering. */
+  maxAttempts: z.number().default(1),
+  /** Retention period in days for completed/failed items. */
+  retentionDays: z.number().default(7),
+  /** Queue creation timestamp. */
+  createdAt: z.string(),
+});
+
+/** Inferred Queue type from schema. */
+export type Queue = z.infer<typeof queueSchema>;

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -49,7 +49,8 @@
     ]
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.11"
+    "@karmaniverous/jeeves": "^0.5.11",
+    "@karmaniverous/jeeves-runner-core": "^0.1.5"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.65.0",

--- a/packages/openclaw/skills/jeeves-runner/SKILL.md
+++ b/packages/openclaw/skills/jeeves-runner/SKILL.md
@@ -257,6 +257,10 @@ jeeves-runner add-job \
 | `overlap_policy` | No | `skip` | `skip` (don't start if already running) or `allow` |
 | `on_failure` | No | config default | Slack channel ID for failure alerts |
 | `on_success` | No | config default | Slack channel ID for success alerts |
+| `output_channel` | No | — | Slack channel ID for stdout relay |
+| `description` | No | — | Human-readable job description |
+| `env` | No | — | `Record<string, string>` — environment variables spread into spawn env alongside `JR_*` vars (script-type jobs only) |
+| `args` | No | — | `string[]` — arguments appended after the script path in the spawn call (script-type jobs only) |
 
 After adding the job, trigger it manually to verify:
 ```bash
@@ -450,7 +454,7 @@ db.prepare('UPDATE jobs SET script = ? WHERE id = ?').run('/path/to/new-script.j
 
 ## Tables
 
-- **jobs** — Job definitions (id, name, schedule, script, source_type, type, enabled, timeout_ms, overlap_policy, description, on_failure, on_success)
+- **jobs** — Job definitions (id, name, schedule, script, source_type, type, enabled, timeout_ms, overlap_policy, description, on_failure, on_success, output_channel, env, args)
 - **runs** — Run history (job_id, status, started_at, duration_ms, exit_code, tokens, error, stdout_tail, stderr_tail, trigger)
 - **state** — Key-value state store with namespaces and optional expiry
 - **state_items** — Collection state (namespace, key, item_key, value)

--- a/packages/openclaw/src/index.test.ts
+++ b/packages/openclaw/src/index.test.ts
@@ -9,6 +9,7 @@ type MockFn = ReturnType<typeof vi.fn>;
 
 vi.mock('@karmaniverous/jeeves', () => {
   return {
+    DEFAULT_BIND_ADDRESS: '0.0.0.0',
     init: vi.fn(),
     getPackageVersion: vi.fn(() => '0.0.0-test'),
     loadWorkspaceConfig: vi.fn(() => null),

--- a/packages/openclaw/src/inspectionTools.ts
+++ b/packages/openclaw/src/inspectionTools.ts
@@ -6,7 +6,7 @@
 
 import type { PluginApi } from '@karmaniverous/jeeves';
 
-import { type ApiToolConfig, registerApiTool } from './toolHelpers.js';
+import { catalogTool, registerApiTool } from './toolHelpers.js';
 
 /** URL-encode a path segment for safe interpolation. */
 function enc(value: unknown): string {
@@ -15,18 +15,21 @@ function enc(value: unknown): string {
 
 /** Register queue and state inspection tools. */
 export function registerInspectionTools(api: PluginApi, baseUrl: string): void {
-  const tools: ApiToolConfig[] = [
-    {
-      name: 'runner_list_queues',
-      description: 'List all queues that have items.',
-      parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/queues'],
-    },
-    {
-      name: 'runner_queue_status',
-      description:
-        'Get queue depth, claimed count, failed count, and oldest item age.',
-      parameters: {
+  const tools = [
+    catalogTool(
+      'listQueues',
+      'runner_list_queues',
+      {
+        type: 'object',
+        properties: {},
+      },
+      () => ['/queues'],
+    ),
+
+    catalogTool(
+      'queueStatus',
+      'runner_queue_status',
+      {
         type: 'object',
         properties: {
           queueName: {
@@ -36,13 +39,13 @@ export function registerInspectionTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['queueName'],
       },
-      buildRequest: (params) => [`/queues/${enc(params.queueName)}/status`],
-    },
-    {
-      name: 'runner_queue_peek',
-      description:
-        'Non-claiming read of pending queue items (does not consume them).',
-      parameters: {
+      (params) => [`/queues/${enc(params.queueName)}/status`],
+    ),
+
+    catalogTool(
+      'queuePeek',
+      'runner_queue_peek',
+      {
         type: 'object',
         properties: {
           queueName: {
@@ -56,25 +59,29 @@ export function registerInspectionTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['queueName'],
       },
-      buildRequest: (params) => {
+      (params) => {
         const query =
           params.limit !== undefined
             ? `?limit=${String(Number(params.limit))}`
             : '';
         return [`/queues/${enc(params.queueName)}/peek${query}`];
       },
-    },
-    {
-      name: 'runner_list_namespaces',
-      description: 'List all state namespaces.',
-      parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/state'],
-    },
-    {
-      name: 'runner_query_state',
-      description:
-        'Read all scalar state for a namespace. Supports optional JSONPath filtering.',
-      parameters: {
+    ),
+
+    catalogTool(
+      'listNamespaces',
+      'runner_list_namespaces',
+      {
+        type: 'object',
+        properties: {},
+      },
+      () => ['/state'],
+    ),
+
+    catalogTool(
+      'queryState',
+      'runner_query_state',
+      {
         type: 'object',
         properties: {
           namespace: {
@@ -88,16 +95,17 @@ export function registerInspectionTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['namespace'],
       },
-      buildRequest: (params) => {
+      (params) => {
         const query =
           params.path !== undefined ? `?path=${enc(params.path)}` : '';
         return [`/state/${enc(params.namespace)}${query}`];
       },
-    },
-    {
-      name: 'runner_query_collection',
-      description: 'Read collection items for a state key within a namespace.',
-      parameters: {
+    ),
+
+    catalogTool(
+      'queryCollection',
+      'runner_query_collection',
+      {
         type: 'object',
         properties: {
           namespace: {
@@ -111,10 +119,8 @@ export function registerInspectionTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['namespace', 'key'],
       },
-      buildRequest: (params) => [
-        `/state/${enc(params.namespace)}/${enc(params.key)}`,
-      ],
-    },
+      (params) => [`/state/${enc(params.namespace)}/${enc(params.key)}`],
+    ),
   ];
 
   for (const tool of tools) {

--- a/packages/openclaw/src/managementTools.ts
+++ b/packages/openclaw/src/managementTools.ts
@@ -7,7 +7,7 @@
 import type { PluginApi } from '@karmaniverous/jeeves';
 
 import {
-  type ApiToolConfig,
+  catalogTool,
   JOB_ID_PARAM,
   jobPath,
   registerApiTool,
@@ -82,12 +82,11 @@ function buildJobBody(
 
 /** Register job management tools (create, update, delete, update_script). */
 export function registerManagementTools(api: PluginApi, baseUrl: string): void {
-  const tools: ApiToolConfig[] = [
-    {
-      name: 'runner_create_job',
-      description:
-        'Create a new runner job. Requires id, name, schedule, and script.',
-      parameters: {
+  const tools = [
+    catalogTool(
+      'createJob',
+      'runner_create_job',
+      {
         type: 'object',
         properties: {
           id: { type: 'string', description: 'Unique job identifier.' },
@@ -95,17 +94,16 @@ export function registerManagementTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['id', 'name', 'schedule', 'script'],
       },
-      method: 'POST',
-      buildRequest: (params) => {
+      (params) => {
         const body = { id: params.id, ...buildJobBody(params) };
         return ['/jobs', body];
       },
-    },
-    {
-      name: 'runner_update_job',
-      description:
-        'Update an existing runner job. Only supplied fields are changed.',
-      parameters: {
+    ),
+
+    catalogTool(
+      'updateJob',
+      'runner_update_job',
+      {
         type: 'object',
         properties: {
           ...JOB_ID_PARAM.properties,
@@ -113,21 +111,17 @@ export function registerManagementTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['jobId'],
       },
-      method: 'PATCH',
-      buildRequest: (params) => [jobPath(params), buildJobBody(params)],
-    },
-    {
-      name: 'runner_delete_job',
-      description: 'Delete a runner job and all its run history. Irreversible.',
-      parameters: JOB_ID_PARAM,
-      method: 'DELETE',
-      buildRequest: (params) => [jobPath(params)],
-    },
-    {
-      name: 'runner_update_script',
-      description:
-        "Update a job's script content or path without changing other fields.",
-      parameters: {
+      (params) => [jobPath(params), buildJobBody(params)],
+    ),
+
+    catalogTool('deleteJob', 'runner_delete_job', JOB_ID_PARAM, (params) => [
+      jobPath(params),
+    ]),
+
+    catalogTool(
+      'updateScript',
+      'runner_update_script',
+      {
         type: 'object',
         properties: {
           ...JOB_ID_PARAM.properties,
@@ -142,15 +136,14 @@ export function registerManagementTools(api: PluginApi, baseUrl: string): void {
         },
         required: ['jobId', 'script'],
       },
-      method: 'PUT',
-      buildRequest: (params) => {
+      (params) => {
         const body: Record<string, unknown> = { script: params.script };
         if (params.source_type !== undefined) {
           body.source_type = params.source_type;
         }
         return [jobPath(params, '/script'), body];
       },
-    },
+    ),
   ];
 
   for (const tool of tools) {

--- a/packages/openclaw/src/managementTools.ts
+++ b/packages/openclaw/src/managementTools.ts
@@ -50,6 +50,21 @@ const JOB_MUTABLE_FIELDS = {
     type: 'string',
     description: 'Slack channel ID for success alerts.',
   },
+  output_channel: {
+    type: 'string',
+    description: 'Slack channel ID for stdout relay.',
+  },
+  env: {
+    type: 'object',
+    description:
+      'Environment variables for script-type jobs. Record<string, string> spread into spawn env alongside JR_* vars. Ignored for session jobs.',
+  },
+  args: {
+    type: 'array',
+    description:
+      'Arguments for script-type jobs. String array appended after the script path in spawn. Ignored for session jobs.',
+    items: { type: 'string' },
+  },
 } as const;
 
 /** Build the request body from params, stripping undefined values. */

--- a/packages/openclaw/src/runnerTools.ts
+++ b/packages/openclaw/src/runnerTools.ts
@@ -13,7 +13,7 @@ import type { PluginApi } from '@karmaniverous/jeeves';
 import { registerInspectionTools } from './inspectionTools.js';
 import { registerManagementTools } from './managementTools.js';
 import {
-  type ApiToolConfig,
+  catalogTool,
   JOB_ID_PARAM,
   jobPath,
   registerApiTool,
@@ -24,27 +24,26 @@ export function registerRunnerCustomTools(
   api: PluginApi,
   baseUrl: string,
 ): void {
-  const coreTools: ApiToolConfig[] = [
-    {
-      name: 'runner_jobs',
-      description:
-        'List all runner jobs with enabled state, schedule, last run status, and last run time.',
-      parameters: { type: 'object', properties: {} },
-      buildRequest: () => ['/jobs'],
-    },
-    {
-      name: 'runner_trigger',
-      description:
-        'Manually trigger a runner job. Blocks until the job completes and returns the run result.',
-      parameters: JOB_ID_PARAM,
-      method: 'POST',
-      buildRequest: (params) => [jobPath(params, '/run'), {}],
-    },
-    {
-      name: 'runner_runs',
-      description:
-        'Get recent run history for a runner job, including status, duration, exit code, and error details.',
-      parameters: {
+  const coreTools = [
+    catalogTool(
+      'listJobs',
+      'runner_jobs',
+      {
+        type: 'object',
+        properties: {},
+      },
+      () => ['/jobs'],
+    ),
+
+    catalogTool('triggerJob', 'runner_trigger', JOB_ID_PARAM, (params) => [
+      jobPath(params, '/run'),
+      {},
+    ]),
+
+    catalogTool(
+      'jobRuns',
+      'runner_runs',
+      {
         ...JOB_ID_PARAM,
         properties: {
           ...JOB_ID_PARAM.properties,
@@ -54,36 +53,28 @@ export function registerRunnerCustomTools(
           },
         },
       },
-      buildRequest: (params) => {
+      (params) => {
         const query =
           params.limit !== undefined
             ? `?limit=${String(Number(params.limit))}`
             : '';
         return [jobPath(params, `/runs${query}`)];
       },
-    },
-    {
-      name: 'runner_job_detail',
-      description:
-        'Get full configuration details for a single runner job, including script path, schedule, timeout, and overlap policy.',
-      parameters: JOB_ID_PARAM,
-      buildRequest: (params) => [jobPath(params)],
-    },
-    {
-      name: 'runner_enable',
-      description: 'Enable a disabled runner job. Takes effect immediately.',
-      parameters: JOB_ID_PARAM,
-      method: 'PATCH',
-      buildRequest: (params) => [jobPath(params, '/enable'), {}],
-    },
-    {
-      name: 'runner_disable',
-      description:
-        'Disable a runner job. The job will not run until re-enabled. Takes effect immediately.',
-      parameters: JOB_ID_PARAM,
-      method: 'PATCH',
-      buildRequest: (params) => [jobPath(params, '/disable'), {}],
-    },
+    ),
+
+    catalogTool('jobDetail', 'runner_job_detail', JOB_ID_PARAM, (params) => [
+      jobPath(params),
+    ]),
+
+    catalogTool('enableJob', 'runner_enable', JOB_ID_PARAM, (params) => [
+      jobPath(params, '/enable'),
+      {},
+    ]),
+
+    catalogTool('disableJob', 'runner_disable', JOB_ID_PARAM, (params) => [
+      jobPath(params, '/disable'),
+      {},
+    ]),
   ];
 
   for (const tool of coreTools) {

--- a/packages/openclaw/src/toolHelpers.ts
+++ b/packages/openclaw/src/toolHelpers.ts
@@ -11,6 +11,10 @@ import {
   type PluginApi,
   type ToolResult,
 } from '@karmaniverous/jeeves';
+import {
+  type EndpointName,
+  getEndpoint,
+} from '@karmaniverous/jeeves-runner-core';
 
 import { PLUGIN_ID } from './constants.js';
 
@@ -81,4 +85,26 @@ export const JOB_ID_PARAM = {
 /** URL-encode the jobId param for safe path interpolation. */
 export function jobPath(params: Record<string, unknown>, suffix = ''): string {
   return `/jobs/${encodeURIComponent(String(params.jobId))}${suffix}`;
+}
+
+/**
+ * Build an ApiToolConfig from the endpoint catalog.
+ *
+ * Derives method, description, and base path from `RUNNER_ENDPOINTS`.
+ * The caller supplies the tool name, parameters, and request builder.
+ */
+export function catalogTool(
+  endpointName: EndpointName,
+  toolName: string,
+  parameters: Record<string, unknown>,
+  buildRequest: ApiToolConfig['buildRequest'],
+): ApiToolConfig {
+  const ep = getEndpoint(endpointName);
+  return {
+    name: toolName,
+    description: ep.description,
+    parameters,
+    method: ep.method,
+    buildRequest,
+  };
 }

--- a/packages/service/src/api/job-routes.test.ts
+++ b/packages/service/src/api/job-routes.test.ts
@@ -251,4 +251,65 @@ describe('Job CRUD routes', () => {
     expect(job.script).toBe('console.log("hi")');
     expect(job.source_type).toBe('inline');
   });
+
+  it('POST /jobs should accept output_channel, env, and args', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/jobs',
+      payload: {
+        id: 'full-job',
+        name: 'Full Job',
+        schedule: '0 * * * *',
+        script: '/path/to/script.ts',
+        output_channel: 'C123CHAN',
+        env: { CUSTOMER: 'vc', MODE: 'live' },
+        args: ['--verbose', '--dry-run'],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+
+    const job = testDb.db
+      .prepare('SELECT output_channel, env, args FROM jobs WHERE id = ?')
+      .get('full-job') as {
+      output_channel: string | null;
+      env: string | null;
+      args: string | null;
+    };
+    expect(job.output_channel).toBe('C123CHAN');
+    expect(JSON.parse(job.env!)).toEqual({ CUSTOMER: 'vc', MODE: 'live' });
+    expect(JSON.parse(job.args!)).toEqual(['--verbose', '--dry-run']);
+  });
+
+  it('PATCH /jobs/:id should update output_channel, env, and args', async () => {
+    testDb.db
+      .prepare(
+        `INSERT INTO jobs (id, name, schedule, script, enabled)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('patch-fields', 'Patch', '0 0 * * *', '/script.js', 1);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/jobs/patch-fields',
+      payload: {
+        output_channel: 'C456CHAN',
+        env: { KEY: 'value' },
+        args: ['--flag'],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const job = testDb.db
+      .prepare('SELECT output_channel, env, args FROM jobs WHERE id = ?')
+      .get('patch-fields') as {
+      output_channel: string | null;
+      env: string | null;
+      args: string | null;
+    };
+    expect(job.output_channel).toBe('C456CHAN');
+    expect(JSON.parse(job.env!)).toEqual({ KEY: 'value' });
+    expect(JSON.parse(job.args!)).toEqual(['--flag']);
+  });
 });

--- a/packages/service/src/api/job-routes.ts
+++ b/packages/service/src/api/job-routes.ts
@@ -6,8 +6,12 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 
+import {
+  createJobSchema,
+  updateJobSchema,
+  updateScriptSchema,
+} from '@karmaniverous/jeeves-runner-core';
 import type { FastifyInstance } from 'fastify';
-import { z } from 'zod';
 
 import { validateSchedule } from '../scheduler/schedule-utils.js';
 import type { Scheduler } from '../scheduler/scheduler.js';
@@ -17,31 +21,6 @@ export interface JobRouteDeps {
   db: DatabaseSync;
   scheduler: Scheduler;
 }
-
-/** Zod schema for job creation/update request body. */
-const createJobSchema = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  schedule: z.string().min(1),
-  script: z.string().min(1),
-  source_type: z.enum(['path', 'inline']).default('path'),
-  type: z.enum(['script', 'session']).default('script'),
-  timeout_seconds: z.number().positive().optional(),
-  overlap_policy: z.enum(['skip', 'allow']).default('skip'),
-  enabled: z.boolean().default(true),
-  description: z.string().optional(),
-  on_failure: z.string().nullable().optional(),
-  on_success: z.string().nullable().optional(),
-});
-
-/** Zod schema for job update (all fields optional except what's set). */
-const updateJobSchema = createJobSchema.omit({ id: true }).partial();
-
-/** Zod schema for script update request body. */
-const updateScriptSchema = z.object({
-  script: z.string().min(1),
-  source_type: z.enum(['path', 'inline']).optional(),
-});
 
 /** Standard error message for missing job resources. */
 const JOB_NOT_FOUND = 'Job not found';
@@ -74,8 +53,8 @@ export function registerJobRoutes(
 
     db.prepare(
       `INSERT INTO jobs (id, name, schedule, script, source_type, type, timeout_ms,
-       overlap_policy, enabled, description, on_failure, on_success)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       overlap_policy, enabled, description, on_failure, on_success, output_channel, env, args)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       data.id,
       data.name,
@@ -89,6 +68,9 @@ export function registerJobRoutes(
       data.description ?? null,
       data.on_failure ?? null,
       data.on_success ?? null,
+      data.output_channel ?? null,
+      data.env ? JSON.stringify(data.env) : null,
+      data.args ? JSON.stringify(data.args) : null,
     );
 
     scheduler.reconcileNow();
@@ -147,6 +129,17 @@ export function registerJobRoutes(
       { input: 'description', column: 'description' },
       { input: 'on_failure', column: 'on_failure' },
       { input: 'on_success', column: 'on_success' },
+      { input: 'output_channel', column: 'output_channel' },
+      {
+        input: 'env',
+        column: 'env',
+        transform: (v) => (v ? JSON.stringify(v) : null),
+      },
+      {
+        input: 'args',
+        column: 'args',
+        transform: (v) => (v ? JSON.stringify(v) : null),
+      },
     ];
 
     const sets: string[] = [];

--- a/packages/service/src/api/routes.ts
+++ b/packages/service/src/api/routes.ts
@@ -15,6 +15,7 @@ import {
   createStatusHandler,
   type JeevesComponentDescriptor,
 } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-runner-core';
 import type { FastifyInstance } from 'fastify';
 
 import type { Scheduler } from '../scheduler/scheduler.js';
@@ -72,7 +73,8 @@ export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
     },
   });
 
-  app.get('/status', async (_request, reply) => {
+  // Route paths reference RUNNER_ENDPOINTS catalog for consistency.
+  app.get(getEndpoint('status').path, async (_request, reply) => {
     const result = await statusHandler();
     return reply.status(result.status).send(result.body);
   });
@@ -92,7 +94,7 @@ export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
   );
 
   // --- GET /jobs ---
-  app.get('/jobs', () => {
+  app.get(getEndpoint('listJobs').path, () => {
     const rows = db
       .prepare(
         `SELECT j.*,

--- a/packages/service/src/cli/jeeves-runner/sync-jobs.ts
+++ b/packages/service/src/cli/jeeves-runner/sync-jobs.ts
@@ -27,6 +27,8 @@ interface JobDefinition {
   source_type?: 'path' | 'inline';
   domain?: string;
   prerequisite?: string | null;
+  env?: Record<string, string>;
+  args?: string[];
 }
 
 /** Result counts from a sync operation. */
@@ -71,8 +73,8 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
   const stmt = db.prepare(
     `INSERT INTO jobs
        (id, name, schedule, script, type, description, enabled, timeout_ms,
-        overlap_policy, on_failure, on_success, output_channel, source_type, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        overlap_policy, on_failure, on_success, output_channel, source_type, env, args, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        name = excluded.name,
        schedule = excluded.schedule,
@@ -86,6 +88,8 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
        on_success = excluded.on_success,
        output_channel = excluded.output_channel,
        source_type = excluded.source_type,
+       env = excluded.env,
+       args = excluded.args,
        updated_at = datetime('now')`,
   );
 
@@ -185,6 +189,8 @@ export function syncJobs(db: DatabaseSync, jobsDir: string): SyncResult {
         job.on_success ?? null,
         job.output_channel ?? null,
         job.source_type ?? 'path',
+        job.env ? JSON.stringify(job.env) : null,
+        job.args ? JSON.stringify(job.args) : null,
       );
 
       if (isUpdate) {

--- a/packages/service/src/db/migrations.ts
+++ b/packages/service/src/db/migrations.ts
@@ -151,6 +151,12 @@ const MIGRATION_005 = `
 ALTER TABLE jobs ADD COLUMN output_channel TEXT DEFAULT NULL;
 `;
 
+/** Migration 006: Add env and args columns to jobs for per-job configuration (#89). */
+const MIGRATION_006 = `
+ALTER TABLE jobs ADD COLUMN env TEXT DEFAULT NULL;
+ALTER TABLE jobs ADD COLUMN args TEXT DEFAULT NULL;
+`;
+
 /** Registry of all migrations keyed by version number. */
 const MIGRATIONS: Record<number, string> = {
   1: MIGRATION_001,
@@ -158,6 +164,7 @@ const MIGRATIONS: Record<number, string> = {
   3: MIGRATION_003,
   4: MIGRATION_004,
   5: MIGRATION_005,
+  6: MIGRATION_006,
 };
 
 /**

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -11,8 +11,13 @@ export { createRunnerDescriptor } from './descriptor.js';
 // Schemas
 export type { RunnerConfig } from './schemas/config.js';
 export { runnerConfigSchema } from './schemas/config.js';
-export type { Job } from './schemas/job.js';
-export { jobSchema } from './schemas/job.js';
+export type { CreateJob, Job, UpdateJob, UpdateScript } from './schemas/job.js';
+export {
+  createJobSchema,
+  jobSchema,
+  updateJobSchema,
+  updateScriptSchema,
+} from './schemas/job.js';
 export type { Queue } from './schemas/queue.js';
 export { queueSchema } from './schemas/queue.js';
 export type { Run, RunStatus, RunTrigger } from './schemas/run.js';

--- a/packages/service/src/scheduler/cron-registry.ts
+++ b/packages/service/src/scheduler/cron-registry.ts
@@ -22,6 +22,9 @@ export interface JobRow {
   on_failure: string | null;
   on_success: string | null;
   source_type?: 'path' | 'inline';
+  output_channel?: string | null;
+  env?: string | null;
+  args?: string | null;
 }
 
 /** Handle for a scheduled job (timeout-based). */

--- a/packages/service/src/scheduler/executor.test.ts
+++ b/packages/service/src/scheduler/executor.test.ts
@@ -107,6 +107,47 @@ describe('executeJob', () => {
     expect(parsed.JR_RUN_ID).toBe('99');
   });
 
+  it('should pass jobEnv to child process', async () => {
+    const script = join(testDir, 'jobenv.js');
+    writeFileSync(
+      script,
+      `console.log(JSON.stringify({ CUSTOMER: process.env.CUSTOMER, MODE: process.env.MODE }));`,
+    );
+
+    const result = await executeJob({
+      script,
+      dbPath: ':memory:',
+      jobId: 'test',
+      runId: 1,
+      jobEnv: { CUSTOMER: 'veterancrowd', MODE: 'live' },
+    });
+
+    expect(result.status).toBe('ok');
+    const parsed = JSON.parse(result.stdoutTail) as Record<string, string>;
+    expect(parsed.CUSTOMER).toBe('veterancrowd');
+    expect(parsed.MODE).toBe('live');
+  });
+
+  it('should append jobArgs after script path', async () => {
+    const script = join(testDir, 'jobargs.js');
+    writeFileSync(
+      script,
+      `console.log(JSON.stringify(process.argv.slice(2)));`,
+    );
+
+    const result = await executeJob({
+      script,
+      dbPath: ':memory:',
+      jobId: 'test',
+      runId: 1,
+      jobArgs: ['--customer', 'veterancrowd', '--live'],
+    });
+
+    expect(result.status).toBe('ok');
+    const parsed = JSON.parse(result.stdoutTail) as string[];
+    expect(parsed).toEqual(['--customer', 'veterancrowd', '--live']);
+  });
+
   it.skipIf(!isWindows)('should execute a .cmd script', async () => {
     const script = join(testDir, 'test.cmd');
     writeFileSync(script, '@echo off\r\necho cmd-output\r\nexit /b 0\r\n');

--- a/packages/service/src/scheduler/executor.ts
+++ b/packages/service/src/scheduler/executor.ts
@@ -55,6 +55,10 @@ export interface ExecutionOptions {
   sourceType?: 'path' | 'inline';
   /** Custom command runners keyed by file extension (e.g. `".ts": "node /path/to/tsx/cli.mjs"`). */
   runners?: Record<string, string>;
+  /** Optional per-job environment variables. Spread into spawn env after JR_* vars. */
+  jobEnv?: Record<string, string>;
+  /** Optional per-job arguments. Appended after the script path in the spawn call. */
+  jobArgs?: string[];
 }
 
 /** Ring buffer for capturing last N lines of output. */
@@ -156,6 +160,8 @@ export function executeJob(
     commandResolver,
     sourceType = 'path',
     runners,
+    jobEnv,
+    jobArgs,
   } = options;
   const startTime = Date.now();
 
@@ -173,15 +179,16 @@ export function executeJob(
     const stdoutBuffer = new RingBuffer(100);
     const stderrBuffer = new RingBuffer(100);
 
-    const { command, args } = commandResolver
+    const { command, args: resolvedArgs } = commandResolver
       ? commandResolver(effectiveScript)
       : resolveCommand(effectiveScript, runners);
-    const child = spawn(command, args, {
+    const child = spawn(command, [...resolvedArgs, ...(jobArgs ?? [])], {
       env: {
         ...process.env,
         JR_DB_PATH: dbPath,
         JR_JOB_ID: jobId,
         JR_RUN_ID: String(runId),
+        ...(jobEnv ?? {}),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/packages/service/src/scheduler/scheduler.ts
+++ b/packages/service/src/scheduler/scheduler.ts
@@ -85,7 +85,19 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
       on_success,
       on_failure,
       source_type,
+      env: envJson,
+      args: argsJson,
     } = job;
+
+    // Parse per-job env and args from JSON TEXT columns (script-type jobs only)
+    const jobEnv =
+      type === 'script' && envJson
+        ? (JSON.parse(envJson) as Record<string, string>)
+        : undefined;
+    const jobArgs =
+      type === 'script' && argsJson
+        ? (JSON.parse(argsJson) as string[])
+        : undefined;
 
     // Check concurrency limit
     if (runningJobs.size >= config.maxConcurrency) {
@@ -123,6 +135,8 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
           timeoutMs: timeout_ms ?? undefined,
           sourceType: source_type ?? 'path',
           runners: config.runners,
+          jobEnv,
+          jobArgs,
         });
       }
 

--- a/packages/service/src/scheduler/scheduler.ts
+++ b/packages/service/src/scheduler/scheduler.ts
@@ -90,14 +90,19 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
     } = job;
 
     // Parse per-job env and args from JSON TEXT columns (script-type jobs only)
-    const jobEnv =
-      type === 'script' && envJson
-        ? (JSON.parse(envJson) as Record<string, string>)
-        : undefined;
-    const jobArgs =
-      type === 'script' && argsJson
-        ? (JSON.parse(argsJson) as string[])
-        : undefined;
+    let jobEnv: Record<string, string> | undefined;
+    let jobArgs: string[] | undefined;
+    if (type === 'script') {
+      try {
+        if (envJson) jobEnv = JSON.parse(envJson) as Record<string, string>;
+        if (argsJson) jobArgs = JSON.parse(argsJson) as string[];
+      } catch (err) {
+        logger.warn(
+          { jobId: id, err },
+          'Failed to parse job env/args JSON, ignoring',
+        );
+      }
+    }
 
     // Check concurrency limit
     if (runningJobs.size >= config.maxConcurrency) {

--- a/packages/service/src/schemas/job.ts
+++ b/packages/service/src/schemas/job.ts
@@ -1,38 +1,17 @@
 /**
  * Job definition schema and types.
  *
- * @module
+ * Delegates to `@karmaniverous/jeeves-runner-core` for the canonical
+ * schema definition. Re-exported here for internal consumers.
  */
 
-import { z } from 'zod';
-
-/** Job definition schema for scheduled tasks. */
-export const jobSchema = z.object({
-  /** Unique job identifier. */
-  id: z.string(),
-  /** Human-readable job name. */
-  name: z.string(),
-  /** Cron expression defining the job schedule. */
-  schedule: z.string(),
-  /** Script path or command to execute. */
-  script: z.string(),
-  /** Job execution type (script or session). */
-  type: z.enum(['script', 'session']).default('script'),
-  /** Optional job description. */
-  description: z.string().optional(),
-  /** Whether the job is enabled for scheduling. */
-  enabled: z.boolean().default(true),
-  /** Optional execution timeout in milliseconds. */
-  timeoutMs: z.number().optional(),
-  /** Policy for handling overlapping job executions (skip or allow). */
-  overlapPolicy: z.enum(['skip', 'allow']).default('skip'),
-  /** Slack channel ID for failure notifications. */
-  onFailure: z.string().nullable().default(null),
-  /** Slack channel ID for success notifications. */
-  onSuccess: z.string().nullable().default(null),
-  /** Output channel identifier for routing session results. */
-  outputChannel: z.string().nullable().default(null),
-});
-
-/** Inferred Job type from schema. */
-export type Job = z.infer<typeof jobSchema>;
+export {
+  type CreateJob,
+  createJobSchema,
+  type Job,
+  jobSchema,
+  type UpdateJob,
+  updateJobSchema,
+  type UpdateScript,
+  updateScriptSchema,
+} from '@karmaniverous/jeeves-runner-core';

--- a/packages/service/src/schemas/queue.ts
+++ b/packages/service/src/schemas/queue.ts
@@ -1,30 +1,8 @@
 /**
  * Queue definition schema and types.
  *
- * @module
+ * Delegates to `@karmaniverous/jeeves-runner-core` for the canonical
+ * schema definition. Re-exported here for internal consumers.
  */
 
-import { z } from 'zod';
-
-/** Queue definition schema for managing queue behavior and retention. */
-export const queueSchema = z.object({
-  /** Unique queue identifier. */
-  id: z.string(),
-  /** Human-readable queue name. */
-  name: z.string(),
-  /** Optional queue description. */
-  description: z.string().nullable().optional(),
-  /** JSONPath expression for deduplication key extraction. */
-  dedupExpr: z.string().nullable().optional(),
-  /** Deduplication scope: 'pending' checks pending/processing items, 'all' checks all non-failed items. */
-  dedupScope: z.enum(['pending', 'all']).default('pending'),
-  /** Maximum retry attempts before dead-lettering. */
-  maxAttempts: z.number().default(1),
-  /** Retention period in days for completed/failed items. */
-  retentionDays: z.number().default(7),
-  /** Queue creation timestamp. */
-  createdAt: z.string(),
-});
-
-/** Inferred Queue type from schema. */
-export type Queue = z.infer<typeof queueSchema>;
+export { type Queue, queueSchema } from '@karmaniverous/jeeves-runner-core';

--- a/packages/service/src/schemas/run.ts
+++ b/packages/service/src/schemas/run.ts
@@ -1,59 +1,15 @@
 /**
  * Run record schema and types.
  *
- * @module
+ * Delegates to `@karmaniverous/jeeves-runner-core` for the canonical
+ * schema definition. Re-exported here for internal consumers.
  */
 
-import { z } from 'zod';
-
-/** Run status enumeration schema (pending, running, ok, error, timeout, skipped). */
-export const runStatusSchema = z.enum([
-  'pending',
-  'running',
-  'ok',
-  'error',
-  'timeout',
-  'skipped',
-]);
-
-/** Run trigger type enumeration schema (schedule, manual, retry). */
-export const runTriggerSchema = z.enum(['schedule', 'manual', 'retry']);
-
-/** Run record schema representing a job execution instance. */
-export const runSchema = z.object({
-  /** Unique run identifier. */
-  id: z.number(),
-  /** Reference to the parent job ID. */
-  jobId: z.string(),
-  /** Current execution status. */
-  status: runStatusSchema,
-  /** ISO timestamp when execution started. */
-  startedAt: z.string().optional(),
-  /** ISO timestamp when execution finished. */
-  finishedAt: z.string().optional(),
-  /** Execution duration in milliseconds. */
-  durationMs: z.number().optional(),
-  /** Process exit code. */
-  exitCode: z.number().optional(),
-  /** Token count for session-type jobs. */
-  tokens: z.number().optional(),
-  /** Additional result metadata (JSON string). */
-  resultMeta: z.string().optional(),
-  /** Error message if execution failed. */
-  error: z.string().optional(),
-  /** Last N characters of stdout. */
-  stdoutTail: z.string().optional(),
-  /** Last N characters of stderr. */
-  stderrTail: z.string().optional(),
-  /** What triggered this run (schedule, manual, or retry). */
-  trigger: runTriggerSchema.default('schedule'),
-});
-
-/** Inferred Run type representing a job execution record. */
-export type Run = z.infer<typeof runSchema>;
-
-/** Inferred RunStatus type from schema. */
-export type RunStatus = z.infer<typeof runStatusSchema>;
-
-/** Inferred RunTrigger type from schema. */
-export type RunTrigger = z.infer<typeof runTriggerSchema>;
+export {
+  type Run,
+  runSchema,
+  type RunStatus,
+  runStatusSchema,
+  type RunTrigger,
+  runTriggerSchema,
+} from '@karmaniverous/jeeves-runner-core';


### PR DESCRIPTION
## Summary

Implements spec §4 (v0.10.0): shared endpoint catalog (#77) and per-job arguments (#89).

### Core (@karmaniverous/jeeves-runner-core)
- **endpoints.ts**: \RUNNER_ENDPOINTS\ catalog (19 entries), \EndpointDescriptor\ type, \getEndpoint()\ helper
- **schemas.ts**: Canonical Zod schemas — \jobSchema\ (with \sourceType\, \outputChannel\, \env\, \rgs\), \createJobSchema\, \updateJobSchema\, \updateScriptSchema\, \unSchema\, \queueSchema\
- **contracts.ts**: Shared response types (\JobListItem\, \RunRecord\, \QueueStatusResponse\, etc.)
- Remove \'retry'\ from \unTriggerSchema\ (DD#46)

### Service (@karmaniverous/jeeves-runner)
- Re-export all schemas from core (replaces inline definitions)
- **Migration 006**: \env TEXT\ and \rgs TEXT\ columns on \jobs\ table
- **executor.ts**: Thread \jobEnv\/\jobArgs\ through \ExecutionOptions\ into \spawn\
- **scheduler.ts**: Parse env/args from job row, pass to executor (script jobs only, ignored for session)
- **job-routes.ts**: Adopt core schemas, add \output_channel\/\env\/\rgs\ to POST and PATCH (resolves DD#44)
- **sync-jobs.ts**: Add \env\/\rgs\ to \JobDefinition\ and UPSERT

### Plugin (@karmaniverous/jeeves-runner-openclaw)
- Add \output_channel\, \env\, \rgs\ to \unner_create_job\ and \unner_update_job\ tool descriptors

### Quality
- Core: 35 tests ✅, typecheck ✅, lint ✅ (0 errors), build ✅
- Service: 163 tests ✅, typecheck ✅, lint ✅ (0 errors), build ✅
- Plugin: 27 tests ✅, typecheck ✅, lint ✅ (0 errors)

Closes #77, closes #89